### PR TITLE
Fix an issue with AngularJS in production

### DIFF
--- a/app/assets/javascripts/app/controllers/admin.coffee
+++ b/app/assets/javascripts/app/controllers/admin.coffee
@@ -1,4 +1,4 @@
-@app.controller 'AdminCtrl', ($scope, $http) ->
+@app.controller 'AdminCtrl', ['$scope', '$http', ($scope, $http) ->
   $scope.users = {} 
   $scope.toggleAdmin = ($user_id) ->
     $http( { method: 'PATCH', url: "/users/#{$user_id}/toggle_admin.json" } ).then(
@@ -7,4 +7,4 @@
       , failureCallback = (response) ->
         console.log response.data['error']
         $scope.users[$user_id] = !$scope.users[$user_id]
-    )
+    )]


### PR DESCRIPTION
In production the Javascript is minified which means that we need
to explicitly tell Angular which parameters are passed into a
controller.