### PR TITLE
Import projects from Gitlab and Github

### DIFF
--- a/.rubocop.todo.yml
+++ b/.rubocop.todo.yml
@@ -12,6 +12,9 @@ AllCops:
 Rails:
   Enabled: true
 
+Metrics/MethodLength:
+  Max: 15
+
 Metrics/ClassLength:
   Exclude:
     - 'test/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,9 @@ AllCops:
 Rails:
   Enabled: true
 
+Metrics/MethodLength:
+  Max: 15
+
 Metrics/ClassLength:
   Exclude:
     - 'test/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,10 @@ gem 'haml'
 gem 'devise'
 gem 'omniauth-github'
 gem 'omniauth-gitlab'
+gem 'oauth2'
+
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -59,10 +63,10 @@ group :test do
 
   # Use Rubocop for style checks
   gem 'rubocop', require: false
-end
 
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+  # Use WebMock to stub web request
+  gem 'webmock', require: false
+end
 
 # Gemified versions of Bower packages for frontend
 source 'https://rails-assets.org' do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,7 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.4.0)
     arel (7.1.1)
     ast (2.3.0)
     bcrypt (3.1.11)
@@ -54,6 +55,8 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
     devise (4.2.0)
       bcrypt (~> 3.0)
@@ -75,6 +78,7 @@ GEM
       activesupport (>= 4.1.0)
     haml (4.0.7)
       tilt
+    hashdiff (0.3.0)
     hashie (3.4.4)
     i18n (0.7.0)
     jbuilder (2.6.0)
@@ -176,6 +180,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
+    safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -217,6 +222,10 @@ GEM
       activemodel (>= 5.0)
       debug_inspector
       railties (>= 5.0)
+    webmock (2.1.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -234,6 +243,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
+  oauth2
   omniauth-github
   omniauth-gitlab
   pg
@@ -250,6 +260,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console
+  webmock
 
 BUNDLED WITH
    1.12.5

--- a/app/assets/javascripts/app/controllers/projects.coffee
+++ b/app/assets/javascripts/app/controllers/projects.coffee
@@ -1,0 +1,31 @@
+@app.controller 'ProjectsCtrl', ['$scope', '$http', '$timeout', ($scope, $http, $timeout) ->
+  $scope.projects = {} 
+  $scope.activateProject = ($origin, $id) ->
+    $scope.projects["#{$origin}-#{$id}"] = 'activating'
+    $http.post(
+      '/projects.json',
+      { project: { origin: $origin, origin_id: $id } }
+    ).then(
+      successCallback = (response) ->
+        $scope.projects["#{$origin}-#{$id}"] = 'active'
+      , failureCallback = (response) ->
+        console.log response.data['error']
+        $scope.projects["#{$origin}-#{$id}"] = 'inactive'
+    )
+
+  $scope.deactivateProject = ($origin, $id) ->
+    $scope.projects["#{$origin}-#{$id}"] = 'deactivating'
+    $http.patch(
+      '/projects/0.json',
+      {
+        origin: $origin, origin_id: $id,
+        project: { active: false }
+      }
+    ).then(
+      successCallback = (response) ->
+        $scope.projects["#{$origin}-#{$id}"] = 'inactive'
+      , failureCallback = (response) ->
+        console.log response.data['error']
+        $scope.projects["#{$origin}-#{$id}"] = 'active'
+    )
+]

--- a/app/models/account_link.rb
+++ b/app/models/account_link.rb
@@ -1,3 +1,5 @@
+require 'open-uri'
+
 class AccountLink < ApplicationRecord
   belongs_to :user
 
@@ -6,11 +8,107 @@ class AccountLink < ApplicationRecord
   validates :uid, uniqueness: { scope: :provider }
 
   def self.from_omniauth(auth)
-    where(provider: auth.provider, uid: auth.uid).first_or_create do |link|
+    l = where(provider: auth.provider, uid: auth.uid).first_or_create do |link|
       link.user = User.where(email: auth.info.email).first_or_create do |user|
         user.name = auth.info.name unless user.name
         user.image = auth.info.image unless user.image
       end
+    end
+
+    # update tokens at every sign in
+    l.token = auth.credentials.token
+    l.secret = auth.credentials.secret
+    l.expires = auth.credentials.expires
+    l.expires_at = auth.credentials.expires_at
+    l.save
+    l
+  end
+
+  def projects
+    case provider
+    when 'gitlab' then gitlab_projects
+    when 'github' then github_projects
+    else []
+    end
+  end
+
+  private
+
+  def gitlab_projects
+    resp = open("https://gitlab.com/api/v3/projects?access_token=#{token}").read
+    JSON.parse(resp).map do |project|
+      {
+        id: project['id'],
+        name: project['path_with_namespace'],
+        description: project['description'],
+        url: project['web_url'],
+        followers: project['star_count'],
+        origin: :gitlab
+      }
+    end
+  end
+
+  def github_projects
+    resp = get('/user/repos').body.to_s
+    JSON.parse(resp).map do |project|
+      {
+        id: project['id'],
+        name: project['full_name'],
+        description: project['description'],
+        url: project['html_url'],
+        followers: project['watchers'],
+        origin: :github
+      }
+    end
+  end
+
+  def request(http_method, path, *arguments)
+    access_token.request(http_method, path, *arguments)
+  end
+
+  def get(path, headers = {})
+    request(:get, path, headers)
+  end
+
+  def head(path, headers = {})
+    request(:head, path, headers)
+  end
+
+  def post(path, body = '', headers = {})
+    request(:post, path, body, headers)
+  end
+
+  def put(path, body = '', headers = {})
+    request(:put, path, body, headers)
+  end
+
+  def patch(path, body = '', headers = {})
+    request(:patch, path, body, headers)
+  end
+
+  def delete(path, headers = {})
+    request(:delete, path, headers)
+  end
+
+  def client
+    return @client if @client
+    @client = OAuth2::Client.new(
+      ENV["#{provider.upcase}_ID"],
+      ENV["#{provider.upcase}_SECRET"],
+      site: provider_url
+    )
+  end
+
+  def access_token
+    return @access_token if @access_token
+    @access_token = OAuth2::AccessToken.new(client, token)
+  end
+
+  def provider_url
+    case provider
+    when 'gitlab' then 'https://gitlab.com/api/v3/'
+    when 'github' then 'https://api.github.com/'
+    else raise "Unsupported OAuth provider #{provider}"
     end
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,3 +1,7 @@
 class Project < ApplicationRecord
   validates :name, presence: true
+  validates :origin, presence: true
+  validates :origin_id, presence: true
+  validates :origin_id, uniqueness: { scope: :origin }
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   devise :trackable
 
   has_many :account_links
+  has_many :projects
 
   validates :email, uniqueness: true
 

--- a/app/views/layouts/projects.html.haml
+++ b/app/views/layouts/projects.html.haml
@@ -1,5 +1,5 @@
 - content_for :content do
-  .container
+  .container{ ng: { controller: 'ProjectsCtrl' } }
     = yield
 
 = render template: 'layouts/application'

--- a/app/views/projects/_project.json.jbuilder
+++ b/app/views/projects/_project.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! project, :id, :name, :coverage, :build_state, :created_at, :updated_at
+json.extract! project, :id, :name, :origin, :origin_id, :active, :coverage, :build_state, :created_at, :updated_at
 json.url project_url(project, format: :json)

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -1,31 +1,20 @@
 .text-center
   %h1 Projects
+  .lead Here is an overview of your active projects
 
-- if Project.exists?
-  %table.table.table-striped
-    %thead 
+%table.table.table-hover
+  %thead
+    %tr
+      %th Name
+      %th Origin ID
+  %tbody
+    - @projects.each do |project|
       %tr
-        %th Name
-        %th Coverage
-        %th Build state
-        %th
-    %tbody
-      - Project.all.each do |project|
-        %tr
-          %td= link_to project.name, project
-          %td= project.coverage
-          %td= project.build_state
-          %td.text-right
-            = link_to edit_project_path(project), class: 'btn btn-xs btn-default' do
-              %span.fa.fa-pencil
-            = link_to project, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger btn-xs' do
-              %span.fa.fa-trash
+        %td
+          = content_tag :span, '', class: "fa fa-fw fa-#{project.origin}"
+          = link_to project.name, project
+        %td
+          = project.origin_id
 
-- else
-  .text-center.alert-container
-    %span.alert.alert-info
-      No projects found
-
-= link_to new_project_path, class: 'btn btn-default' do
-  %span.fa.fa-plus
-  New Project
+.text-center
+  = link_to 'Setup Projects', setup_projects_path, class: 'btn btn-default'

--- a/app/views/projects/setup.html.haml
+++ b/app/views/projects/setup.html.haml
@@ -1,0 +1,29 @@
+.text-center
+  %h1 Setup Projects
+  .lead Select the projects you want to track
+
+- if @projects.any?
+  %table.table.table-hover
+    %tbody
+      - @projects.each do |project|
+        - uniq_id = [project[:origin],project[:id]].join '-'
+        %tr{ ng: { init: "projects['#{uniq_id}'] = '#{project[:state]}'"}}
+          %td
+            = content_tag :span, '', class: "fa fa-fw fa-#{project[:origin]}"
+            = link_to project[:name], project[:url], target: '_blank'
+          %td.text-right
+            .btn.btn-success{ disabled: true, ng: { show: "projects['#{uniq_id}'] == 'activating'" }}
+              %span.fa.fa-spinner.fa-pulse.fa-fw
+              Activating
+            .btn.btn-success{ ng: { show: "projects['#{uniq_id}'] == 'inactive'", click: "activateProject('#{project[:origin]}', '#{project[:id]}')" }}
+              Activate
+            .btn.btn-danger{ disabled: true, ng: { show: "projects['#{uniq_id}'] == 'deactivating'" }}
+              %span.fa.fa-spinner.fa-pulse.fa-fw
+              Deactivating
+            .btn.btn-danger{ ng: { show: "projects['#{uniq_id}'] == 'active'", click: "deactivateProject('#{project[:origin]}', '#{project[:id]}')" }}
+              Deactivate
+
+- else
+  .text-center.alert-container
+    %span.alert.alert-info
+      No projects found

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,9 @@ Rails.application.routes.draw do
   end
 
   # resources
-  resources :projects
+  resources :projects do
+    get 'setup', on: :collection
+  end
 
   # static
   get '/about', to: 'static#about'

--- a/db/migrate/20160903190734_add_more_to_projects.rb
+++ b/db/migrate/20160903190734_add_more_to_projects.rb
@@ -1,0 +1,9 @@
+class AddMoreToProjects < ActiveRecord::Migration[5.0]
+  def change
+    add_column :projects, :origin, :string
+    add_reference :projects, :user, foreign_key: true
+    add_column :projects, :description, :string
+    add_column :projects, :active, :boolean
+    add_column :projects, :origin_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160902174544) do
+ActiveRecord::Schema.define(version: 20160903190734) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,12 @@ ActiveRecord::Schema.define(version: 20160902174544) do
     t.string   "build_state"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.string   "origin"
+    t.integer  "user_id"
+    t.string   "description"
+    t.boolean  "active"
+    t.integer  "origin_id"
+    t.index ["user_id"], name: "index_projects_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade do |t|
@@ -52,4 +58,5 @@ ActiveRecord::Schema.define(version: 20160902174544) do
   end
 
   add_foreign_key "account_links", "users"
+  add_foreign_key "projects", "users"
 end

--- a/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/omniauth_callbacks_controller_test.rb
@@ -11,6 +11,9 @@ class Users::OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
         email: 'test@mail.com',
         name: 'Test User',
         image: 'test'
+      },
+      credentials: {
+        token: 'test'
       }
     )
     OmniAuth.config.mock_auth[:gitlab] = OmniAuth::AuthHash.new(
@@ -20,6 +23,9 @@ class Users::OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
         email: 'test@mail.com',
         name: 'Test User',
         image: 'test'
+      },
+      credentials: {
+        token: 'test'
       }
     )
   end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -19,6 +19,23 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'index should redirect when no projects' do
+    sign_in users(:bob)
+    get projects_url
+    assert_redirected_to setup_projects_path
+  end
+
+  test 'should not get setup logged out' do
+    get setup_projects_path
+    assert_redirected_to new_user_session_path
+  end
+
+  test 'should get setup' do
+    sign_in users(:alice)
+    get setup_projects_path
+    assert_response :success
+  end
+
   test 'should not get new logged out' do
     get new_project_url
     assert_redirected_to new_user_session_path
@@ -51,6 +68,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
       post projects_url,
            params: {
              project: {
+               origin: 'test',
+               origin_id: 123,
                build_state: @project.build_state,
                coverage: @project.coverage,
                name: @project.name
@@ -59,22 +78,6 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to project_url(Project.last)
-  end
-
-  test 'should not create project without name' do
-    sign_in users(:alice)
-    assert_no_difference('Project.count') do
-      post projects_url,
-           params: {
-             project: {
-               build_state: @project.build_state,
-               coverage: @project.coverage
-             }
-           }
-    end
-
-    assert_response :success
-    assert_select 'li', "Name can't be blank"
   end
 
   test 'should not show project logged out' do
@@ -110,11 +113,22 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to project_url(@project)
   end
 
-  test 'should not remove name from project' do
+  test 'should not remove origin from project' do
     sign_in users(:alice)
-    patch project_url(@project), params: { project: { build_state: @project.build_state, coverage: @project.coverage, name: nil } }
+    patch project_url(@project), params: { project: {
+      origin: nil
+    } }
     assert_response :success
-    assert_select 'li', "Name can't be blank"
+    assert_select 'li', "Origin can't be blank"
+  end
+
+  test 'should not remove origin_id from project' do
+    sign_in users(:alice)
+    patch project_url(@project), params: { project: {
+      origin_id: nil
+    } }
+    assert_response :success
+    assert_select 'li', "Origin can't be blank"
   end
 
   test 'should not destroy project logged out' do

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -2,10 +2,16 @@
 
 project1:
   name: Project1
+  origin: gitlab
+  origin_id: 123
+  user: alice
   coverage: 1
   build_state: success
 
 project2:
   name: Project2
+  origin: github
+  origin_id: 123
+  user: alice
   coverage: 95
   build_state: failed

--- a/test/models/account_link_test.rb
+++ b/test/models/account_link_test.rb
@@ -42,4 +42,32 @@ class AccountLinkTest < ActiveSupport::TestCase
     )
     assert !link.save
   end
+
+  test 'should get gitlab projects' do
+    stub_request(:get, 'https://gitlab.com/api/v3/projects?access_token=mytoken')
+      .to_return(body: [{ id: 42 }, { id: 1337 }].to_json)
+    link = AccountLink.new(
+      user: users(:alice),
+      provider: 'gitlab',
+      uid: 'test',
+      token: 'mytoken'
+    )
+    assert_equal 2, link.projects.count
+    assert_equal 42, link.projects[0][:id]
+    assert_equal 1337, link.projects[1][:id]
+  end
+
+  test 'should get github projects' do
+    stub_request(:get, 'https://api.github.com/user/repos')
+      .to_return(body: [{ id: 42 }, { id: 1337 }].to_json)
+    link = AccountLink.new(
+      user: users(:alice),
+      provider: 'github',
+      uid: 'test',
+      token: 'mytoken'
+    )
+    assert_equal 2, link.projects.count
+    assert_equal 42, link.projects[0][:id]
+    assert_equal 1337, link.projects[1][:id]
+  end
 end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -1,8 +1,50 @@
 require 'test_helper'
 
 class ProjectTest < ActiveSupport::TestCase
+  test 'should not create project without origin' do
+    project = Project.new(
+      name: 'test',
+      origin_id: 123,
+      user: users(:bob)
+    )
+    assert !project.save, 'Saved without origin'
+  end
+
+  test 'should not create project without origin_id' do
+    project = Project.new(
+      name: 'test',
+      origin: 'test',
+      user: users(:bob)
+    )
+    assert !project.save, 'Saved without origin_id'
+  end
+
+  test 'should not create project without user' do
+    project = Project.new(
+      name: 'test',
+      origin: 'test',
+      origin_id: 123
+    )
+    assert !project.save, 'Saved without user'
+  end
+
+  test 'should not create project with existing origin and origin_id' do
+    existing_project = Project.first
+    project = Project.new(
+      name: 'test',
+      origin: existing_project.origin,
+      origin_id: existing_project.origin_id
+    )
+    assert !project.save, 'Saved duplicate project'
+  end
+
   test 'should create project' do
-    project = Project.new(name: 'test')
-    assert project.save
+    project = Project.new(
+      name: 'test',
+      origin: 'test',
+      origin_id: 123,
+      user: users(:bob)
+    )
+    assert project.save, 'Did not save project'
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,8 +5,18 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
+require 'webmock/minitest'
+
 OmniAuth.config.test_mode = true
 
 class ActiveSupport::TestCase
   fixtures :all
+
+  def setup
+    WebMock.disable_net_connect!(allow_localhost: true)
+  end
+
+  def teardown
+    WebMock.allow_net_connect!
+  end
 end


### PR DESCRIPTION
Allow users to list all their projects from Gitlab and Github and
select the projects to import into Appatite.

If the user has no projects active, they are redirected to the
setup page automatically.

When projects are deactivated they are not removed, just marked as
inactive, this will keep any future settings for the project, in
case the user reactivates them.

Fixes #7