### PR TITLE
Refactor AccountLink by breaking out code to concerns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/) 
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-*Nothing yet*
+- Log in using your Gitlab or Github account.
+- Import projects from Gitlab or Github.
+- Admin area with list of registered users.
 
 [Unreleased]: https://github.com/ephracis/appatite/compare/8c736d6...HEAD

--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ group :test do
   gem 'rubocop', require: false
 
   # Use WebMock to stub web request
-  gem 'webmock', require: false
+  gem 'webmock'
 end
 
 # Gemified versions of Bower packages for frontend

--- a/app/models/account_link.rb
+++ b/app/models/account_link.rb
@@ -7,6 +7,10 @@ class AccountLink < ApplicationRecord
   validates :uid, presence: true
   validates :uid, uniqueness: { scope: :provider }
 
+  include OauthClient
+  include Gitlab
+  include Github
+
   def self.from_omniauth(auth)
     l = where(provider: auth.provider, uid: auth.uid).first_or_create do |link|
       link.user = User.where(email: auth.info.email).first_or_create do |user|
@@ -34,81 +38,11 @@ class AccountLink < ApplicationRecord
 
   private
 
-  def gitlab_projects
-    resp = open("https://gitlab.com/api/v3/projects?access_token=#{token}").read
-    JSON.parse(resp).map do |project|
-      {
-        id: project['id'],
-        name: project['path_with_namespace'],
-        description: project['description'],
-        url: project['web_url'],
-        followers: project['star_count'],
-        origin: :gitlab
-      }
-    end
-  end
-
-  def github_projects
-    resp = get('/user/repos').body.to_s
-    JSON.parse(resp).map do |project|
-      {
-        id: project['id'],
-        name: project['full_name'],
-        description: project['description'],
-        url: project['html_url'],
-        followers: project['watchers'],
-        origin: :github
-      }
-    end
-  end
-
-  def request(http_method, path, *arguments)
-    access_token.request(http_method, path, *arguments)
-  end
-
-  def get(path, headers = {})
-    request(:get, path, headers)
-  end
-
-  def head(path, headers = {})
-    request(:head, path, headers)
-  end
-
-  def post(path, body = '', headers = {})
-    request(:post, path, body, headers)
-  end
-
-  def put(path, body = '', headers = {})
-    request(:put, path, body, headers)
-  end
-
-  def patch(path, body = '', headers = {})
-    request(:patch, path, body, headers)
-  end
-
-  def delete(path, headers = {})
-    request(:delete, path, headers)
-  end
-
-  def client
-    return @client if @client
-    @client = OAuth2::Client.new(
-      ENV["#{provider.upcase}_ID"],
-      ENV["#{provider.upcase}_SECRET"],
-      site: provider_url
-    )
-  end
-
-  def access_token
-    return @access_token if @access_token
-    @access_token = OAuth2::AccessToken.new(client, token)
-  end
-
   def provider_url
     case provider
-    when 'gitlab' then 'https://gitlab.com/api/v3/'
-    when 'github' then 'https://api.github.com/'
-    else raise "Unsupported OAuth provider #{provider}"
+    when 'gitlab' then gitlab_url
+    when 'github' then github_url
+    else super
     end
   end
 end

--- a/app/models/concerns/github.rb
+++ b/app/models/concerns/github.rb
@@ -1,0 +1,23 @@
+require 'active_support/concern'
+
+module Github
+  extend ActiveSupport::Concern
+
+  def github_projects
+    resp = get('/user/repos').body.to_s
+    JSON.parse(resp).map do |project|
+      {
+        id: project['id'],
+        name: project['full_name'],
+        description: project['description'],
+        url: project['html_url'],
+        followers: project['watchers'],
+        origin: :github
+      }
+    end
+  end
+
+  def github_url
+    'https://api.github.com/'
+  end
+end

--- a/app/models/concerns/gitlab.rb
+++ b/app/models/concerns/gitlab.rb
@@ -1,0 +1,23 @@
+require 'active_support/concern'
+
+module Gitlab
+  extend ActiveSupport::Concern
+
+  def gitlab_projects
+    resp = open("https://gitlab.com/api/v3/projects?access_token=#{token}").read
+    JSON.parse(resp).map do |project|
+      {
+        id: project['id'],
+        name: project['path_with_namespace'],
+        description: project['description'],
+        url: project['web_url'],
+        followers: project['star_count'],
+        origin: :gitlab
+      }
+    end
+  end
+
+  def gitlab_url
+    'https://gitlab.com/api/v3/'
+  end
+end

--- a/app/models/concerns/oauth_client.rb
+++ b/app/models/concerns/oauth_client.rb
@@ -1,0 +1,51 @@
+require 'active_support/concern'
+
+module OauthClient
+  extend ActiveSupport::Concern
+
+  def request(http_method, path, *arguments)
+    access_token.request(http_method, path, *arguments)
+  end
+
+  def get(path, headers = {})
+    request(:get, path, headers)
+  end
+
+  def head(path, headers = {})
+    request(:head, path, headers)
+  end
+
+  def post(path, body = '', headers = {})
+    request(:post, path, body, headers)
+  end
+
+  def put(path, body = '', headers = {})
+    request(:put, path, body, headers)
+  end
+
+  def patch(path, body = '', headers = {})
+    request(:patch, path, body, headers)
+  end
+
+  def delete(path, headers = {})
+    request(:delete, path, headers)
+  end
+
+  def client
+    return @client if @client
+    @client = OAuth2::Client.new(
+      ENV["#{provider.upcase}_ID"],
+      ENV["#{provider.upcase}_SECRET"],
+      site: provider_url
+    )
+  end
+
+  def access_token
+    return @access_token if @access_token
+    @access_token = OAuth2::AccessToken.new(client, token)
+  end
+
+  def provider_url
+    raise "Unsupported OAuth provider #{provider}"
+  end
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = false
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
Move out code for OAuth, Gitlab and Github from `AccountLink`
to three concerns responsible for each part.

For now, Gitlab and Gitlab requires the OAuthClient concern to
make the API calls, leaving it up to the using class to include this
concern. It would be nice if the Gitlab and Github concerns could
include this themselves.

Fixes #17