### PR TITLE
Fix incorrect URL to Redis server

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,4 +6,4 @@ test:
 
 production:
   adapter: redis
-  url: Hide redis://h:p1p1tmvou4coeiengbklan8dcua@ec2-54-247-91-92.eu-west-1.compute.amazonaws.com:18829
+  url: redis://h:p1p1tmvou4coeiengbklan8dcua@ec2-54-247-91-92.eu-west-1.compute.amazonaws.com:18829


### PR DESCRIPTION
The copy-paste of the Redis URL contained a bad string. Strange that
this does not cause the server to crash locally, even when running
in production mode.

Hopefully this should fix the production issue, but I feel like I am
flying a bit blind here...