### PR TITLE
Add Vagrant for easy development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ build-iPhoneSimulator/
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
+.vagrant/

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,9 @@ gem 'puma', '~> 3.0'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 
+# Javascript runtime
+gem 'therubyracer'
+
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
       thor (>= 0.14, < 2.0)
     json (2.0.2)
     jwt (1.5.4)
+    libv8 (3.16.14.15)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -172,6 +173,7 @@ GEM
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     redis (3.3.1)
+    ref (2.0.0)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
     rubocop (0.42.0)
@@ -205,6 +207,9 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    therubyracer (0.12.2)
+      libv8 (~> 3.16.14.0)
+      ref
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -258,6 +263,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
+  therubyracer
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/README.md
+++ b/README.md
@@ -7,31 +7,17 @@
 
 This is the project for the Appatite website.
 
-## Prerequisites
-- Ruby (use [rvm](http://rvm.io))
-- Postgres
-  - `brew install postgres`
-  - `initdb /usr/local/var/postgres -E utf8`
-  - `gem install lunchy`
-  - `mkdir -p ~/Library/LaunchAgents`
-  - `cp /usr/local/Cellar/postgresql/<VERSION>/homebrew.mxcl.postgresql.plist ~/Library/LaunchAgents/`
-  - `luncy start postgres`
+## Get started
 
-## Getting started
-Install bundler with `gem install bundler` and then install all depencencies
-by running `bundle`.
-
-Create the database using the command `bin/rails db:setup`.
-
-## Configuration
+### Configuration
 To enable signing in with Github or Gitlab you need to register an app
 with those providers and save your ID and secret in the configuration file.
 
 Register your application to get your ID and secret:
-- [Github](https://github.com/settings/developers)
-  - Callback URL: http://example.com/users/auth/gitlab/callback
-- [Gitlab](https://gitlab.com/profile/applications)
-  - Callback URL: http://example.com/users/auth/github/callback
+- Go to [Github](https://github.com/settings/developers) and set
+  callback URL to `http://<HOSTNAME>/users/auth/gitlab/callback`
+- Go to [Gitlab](https://gitlab.com/profile/applications) and set
+  callback URL to `http://<HOSTNAME>/users/auth/github/callback`
 
 Then create the file `.env` and put in your tokens:
 
@@ -42,8 +28,59 @@ GITHUB_ID=...
 GITHUB_SECRET=...
 ```
 
+### Vagrant
+The easiest way to get everything installed is by using [Vagrant](vagrantup.com).
+Run the following command to spin up a dev machine running the app:
+
+    vagrant up
+
+You can now access the app on http://localhost:3000.
+
+### Manually
+Follow these steps to install the web app manually on a system.
+
+#### Ruby
+Install Ruby using [rvm](http://rvm.io) or rbenv. Recommended version is 2.3.1.
+
+For RVM, do the following:
+
+    gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+    curl -sSL https://get.rvm.io | bash -s stable --rails --ruby=2.3.1
+
+#### Postgres
+Install PostgreSQL by issuing the following commands:
+
+##### macOS Sierra
+
+    brew install postgres
+    initdb /usr/local/var/postgres -E utf8
+    gem install lunchy
+    mkdir -p ~/Library/LaunchAgents
+    cp /usr/local/Cellar/postgresql/<VERSION>/homebrew.mxcl.postgresql.plist ~/Library/LaunchAgents/
+    lunchy start postgres
+
+##### Ubuntu 16.04
+
+    apt-get -y install postgresql postgresql-contrib libpq-dev
+    sudo su - postgres -c 'createuser $(whoami) -s;'
+
+#### Bundler
+Install Bundler for managing Ruby gems:
+
+    gem install Bundler
+
+#### Ruby gems
+Continue to install all Ruby gem dependencies for the web app:
+
+    bundle
+
+#### Create database
+Create the database
+
+    bin/rails db:setup
+
 ## Run tests
-Lint the code with the command `rubocop`.
+Lint the code with the command `rubocop -aD`.
 
 Run the test by issuing the command `bin/rails test`.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,25 @@
+Vagrant.configure(2) do |config|
+  config.vm.box = 'bento/ubuntu-16.04'
+  config.vm.network 'forwarded_port', guest: 3000, host: 3000
+  config.vm.provision 'shell', inline: <<-SHELL
+     set -e
+     update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8
+     apt-get update
+     apt-get install -y postgresql postgresql-contrib curl libpq-dev
+     set +e
+     su - postgres -c 'createuser vagrant -s; createuser root -s'
+     set -e
+     su - vagrant
+     gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+     curl -sSL https://get.rvm.io | bash -s stable --rails --ruby=2.3.1
+     source /usr/local/rvm/scripts/rvm
+     cd /vagrant
+     gem install bundle
+     bundle install
+     set +e
+     bin/rails db:create
+     set -e
+     bin/rails db:migrate
+     bin/rails server -b 0.0.0.0 -p 3000
+  SHELL
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
   validates :email, uniqueness: true
 
   def self.new_with_session(params, session)
-    super.tap do |user|
+    super.tap do |_user|
     end
   end
 


### PR DESCRIPTION
Create a Vagrantfile which allows anyone with vagrant to spin up
dev machines with all the dependencies installed and configured
properly.

All that is left to the user is setting up the `.env` file.

Fixes #29