### PR TITLE
Inject webhooks into repositories when activated

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,11 +13,20 @@ Rails:
   Enabled: true
 
 Metrics/MethodLength:
-  Max: 15
+  Max: 20
 
 Metrics/ClassLength:
+  Max: 200
   Exclude:
     - 'test/**/*'
+
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - 'app/controllers/projects_controller.rb'
+
+Metrics/PerceivedComplexity:
+  Exclude:
+    - 'app/controllers/projects_controller.rb'
 
 Style/FrozenStringLiteralComment:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 [![Build Status](https://travis-ci.org/ephracis/appatite.svg?branch=master)](https://travis-ci.org/ephracis/appatite)
 [![Code Climate](https://codeclimate.com/github/ephracis/appatite/badges/gpa.svg)](https://codeclimate.com/github/ephracis/appatite)
 [![Test Coverage](https://codeclimate.com/github/ephracis/appatite/badges/coverage.svg)](https://codeclimate.com/github/ephracis/appatite/coverage)
+[![Stories in progress](https://badge.waffle.io/ephracis/appatite.svg?label=in%20progress&title=in%20progress)](http://waffle.io/ephracis/appatite)
 [![GitHub license](https://img.shields.io/badge/license-GPLv3-blue.svg)](https://raw.githubusercontent.com/ephracis/appatite/master/LICENSE)
+[![Issue Stats](http://www.issuestats.com/github/ephracis/appatite/badge/pr?style=flat)](http://www.issuestats.com/github/ephracis/appatite)
+[![Issue Stats](http://www.issuestats.com/github/ephracis/appatite/badge/issue?style=flat)](http://www.issuestats.com/github/ephracis/appatite)
 
 # Welcome to Appatite
 
-This is the project for the Appatite website.
+This is the project for the [Appatite website](appatite.herokuapp.com).
 
 ## Get started
 
@@ -13,11 +16,9 @@ This is the project for the Appatite website.
 To enable signing in with Github or Gitlab you need to register an app
 with those providers and save your ID and secret in the configuration file.
 
-Register your application to get your ID and secret:
-- Go to [Github](https://github.com/settings/developers) and set
-  callback URL to `http://<HOSTNAME>/users/auth/gitlab/callback`
-- Go to [Gitlab](https://gitlab.com/profile/applications) and set
-  callback URL to `http://<HOSTNAME>/users/auth/github/callback`
+Register your application on [Github](https://github.com/settings/developers)
+and [Gitlab](https://gitlab.com/profile/applications) to get your ID and secret.
+Set callback URL to `http://<HOSTNAME>/users/auth/gitlab/callback`.
 
 Then create the file `.env` and put in your tokens:
 

--- a/app/assets/javascripts/app/controllers/projects.coffee
+++ b/app/assets/javascripts/app/controllers/projects.coffee
@@ -1,10 +1,10 @@
 @app.controller 'ProjectsCtrl', ['$scope', '$http', ($scope, $http) ->
   $scope.projects = {}
-  $scope.activateProject = ($origin, $id) ->
+  $scope.activateProject = ($origin, $id, $api_url) ->
     $scope.projects["#{$origin}-#{$id}"]['state'] = 'activating'
     $http.post(
       '/projects.json',
-      { project: { origin: $origin, origin_id: $id } }
+      { project: { origin: $origin, origin_id: $id, api_url: $api_url } }
     ).then(
       successCallback = (response) ->
         $scope.projects["#{$origin}-#{$id}"]['state'] = 'active'
@@ -13,12 +13,12 @@
         $scope.projects["#{$origin}-#{$id}"]['state'] = 'inactive'
     )
 
-  $scope.deactivateProject = ($origin, $id) ->
+  $scope.deactivateProject = ($origin, $id, $api_url) ->
     $scope.projects["#{$origin}-#{$id}"]['state'] = 'deactivating'
     $http.patch(
       '/projects/0.json',
       {
-        origin: $origin, origin_id: $id,
+        origin: $origin, origin_id: $id, api_url: $api_url,
         project: { active: false }
       }
     ).then(

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   after_action :set_csrf_cookie_for_ng
+  before_action :fill_project_metadata
 
   # Ensure that Angular AJAX requests carry the authenticity token
   def set_csrf_cookie_for_ng
@@ -23,5 +24,26 @@ class ApplicationController < ActionController::Base
   # Extend the CSRF verification to allow Angular AJAX calls
   def verified_request?
     super || valid_authenticity_token?(session, request.headers['X-XSRF-TOKEN'])
+  end
+
+  # TODO: Temporary method for filling out api_url on projects
+  def fill_project_metadata
+    if Project.where(api_url: nil).any?
+      projects = []
+      User.all.each { |u| u.account_links.each { |l| projects += l.projects } }
+      logger.info projects.to_yaml
+      projects.each do |hash|
+        p = Project.find_by(
+          origin: hash[:origin],
+          origin_id: hash[:id]
+        )
+        logger.info "Project: #{hash[:name]}"
+        logger.info p.inspect
+        p.update_attributes!(
+          name: hash[:name],
+          api_url: hash[:api_url]
+        ) if p
+      end
+    end
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,11 +1,11 @@
 class ProjectsController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: :webhook
   before_action :set_project, only: [:show, :edit, :update, :destroy]
 
   # GET /projects
   # GET /projects.json
   def index
-    @projects = current_user.projects.order(:id)
+    @projects = current_user.projects.where(active: true).order(:id)
     redirect_to(setup_projects_path) && return unless @projects.any?
   end
 
@@ -22,6 +22,25 @@ class ProjectsController < ApplicationController
       uniq_id = "#{project[:origin]}-#{project[:id]}"
       project[:state] =
         uniq_id.in?(active_projects) ? :active : :inactive
+    end
+  end
+
+  # POST /projects/webhook
+  def webhook
+    payload = JSON.parse(request.body.read)
+    if request.headers['X-GitHub-Event']
+      api_url = payload['repository']['url']
+    elsif payload['project']
+      api_url = "https://gitlab.com/api/v3/projects/#{payload['project']['id']}"
+    else
+      render(json: { error: 'Could not recognize the request' }, status: :unprocessable_entity) && return
+    end
+    project = Project.find_by(api_url: api_url)
+    project.receive_hook(payload) if project
+    if project && project.save
+      head :ok
+    else
+      format.json { render json: project.errors, status: :unprocessable_entity }
     end
   end
 
@@ -42,14 +61,19 @@ class ProjectsController < ApplicationController
   # POST /projects
   # POST /projects.json
   def create
-    @project = Project.where(project_params).first_or_initialize do |p|
+    @project = Project.where(
+      api_url: project_params[:api_url]
+    ).first_or_initialize do |p|
       p.user = current_user
-      p.name = 'Test project'
+      p.origin = project_params[:origin]
+      p.origin_id = project_params[:origin_id]
+      p.active = true
+      p.refresh
     end
-    @project.active = true
 
     respond_to do |format|
       if @project.save
+        @project.create_hook(webhook_projects_url) # TODO: send notification on error
         format.html { redirect_to @project, notice: 'Project was successfully created.' }
         format.json { render :show, status: :created, location: @project }
       else
@@ -62,8 +86,14 @@ class ProjectsController < ApplicationController
   # PATCH/PUT /projects/1
   # PATCH/PUT /projects/1.json
   def update
+    old_state = @project.active
     respond_to do |format|
       if @project.update(project_params)
+        if old_state != @project.active && @project.active
+          @project.create_hook(webhook_projects_url)
+        elsif old_state != @project.active
+          @project.delete_hook(webhook_projects_url)
+        end
         ProjectChannel.broadcast_to @project.user, @project
         format.html { redirect_to @project, notice: 'Project was successfully updated.' }
         format.json { render :show, status: :ok, location: @project }
@@ -77,6 +107,7 @@ class ProjectsController < ApplicationController
   # DELETE /projects/1
   # DELETE /projects/1.json
   def destroy
+    @project.delete_hook(webhook_projects_url)
     @project.destroy
     respond_to do |format|
       format.html { redirect_to projects_url, notice: 'Project was successfully destroyed.' }
@@ -88,7 +119,9 @@ class ProjectsController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_project
-    @project = if params[:origin] && params[:origin_id]
+    @project = if params[:api_url]
+                 Project.find_by api_url: params[:api_url]
+               elsif params[:origin] && params[:origin_id]
                  Project.find_by(
                    origin: params[:origin],
                    origin_id: params[:origin_id]
@@ -100,6 +133,8 @@ class ProjectsController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def project_params
-    params.require(:project).permit(:active, :origin, :origin_id, :coverage, :build_state, :name)
+    params.require(:project).permit(
+      :active, :origin, :origin_id, :coverage, :build_state, :name, :api_url
+    )
   end
 end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -3,5 +3,14 @@ class StaticController < ApplicationController
   end
 
   def about
+    l = current_user.account_links.find_by(provider: :github)
+    project = JSON.parse(l.send(:get, 'https://api.github.com/repos/ephracis/appatite').body)
+    name = project['full_name']
+    statuses = JSON.parse(l.send(:get, "/repos/#{name}/statuses/HEAD").body)
+    if statuses.length.positive?
+      render json: statuses[0]['state']
+    else
+      render json: { error: 'no statuses' }
+    end
   end
 end

--- a/app/models/concerns/github.rb
+++ b/app/models/concerns/github.rb
@@ -4,13 +4,13 @@ module Github
   extend ActiveSupport::Concern
 
   def github_projects
-    resp = get('/user/repos').body.to_s
-    JSON.parse(resp).map do |project|
+    JSON.parse(get('/user/repos').body).map do |project|
       {
+        url: project['html_url'],
+        api_url: project['url'],
         id: project['id'],
         name: project['full_name'],
         description: project['description'],
-        url: project['html_url'],
         followers: project['watchers'],
         origin: :github
       }
@@ -19,5 +19,50 @@ module Github
 
   def github_url
     'https://api.github.com/'
+  end
+
+  def fetch_github_project
+    project = JSON.parse(get(api_url).body)
+    statuses = JSON.parse(get("repos/#{project['full_name']}/statuses/HEAD").body)
+    retval = {
+      name: project['full_name'],
+      description: project['description']
+    }
+    retval[:state] = statuses[0]['state'] if statuses.length.positive?
+    retval
+  end
+
+  def create_github_webhook(url)
+    hook_data = {
+      name: 'appatite',
+      active: true,
+      events: [:status],
+      config: {
+        url: url,
+        content_type: :json
+      }
+    }
+    post("#{api_url}/hooks", body: hook_data.to_json)
+  end
+
+  def delete_github_webhook(url)
+    hooks = JSON.parse(get("#{api_url}/hooks").body)
+    hook = hooks.find { |h| h['config']['url'] == url }
+    delete("#{api_url}/hooks/#{hook['id']}") if hook
+  end
+
+  def receive_github_webhook(payload)
+    self.name = payload['repository']['full_name']
+    self.description = payload['repository']['description']
+    self.build_state = translate_state payload['state']
+  end
+
+  def translate_state(state)
+    case state
+    when 'pending' then 'running'
+    when 'passed' then 'success'
+    when 'failed' then 'failed'
+    else 'unknown'
+    end
   end
 end

--- a/app/models/concerns/gitlab.rb
+++ b/app/models/concerns/gitlab.rb
@@ -4,13 +4,13 @@ module Gitlab
   extend ActiveSupport::Concern
 
   def gitlab_projects
-    resp = open("https://gitlab.com/api/v3/projects?access_token=#{token}").read
-    JSON.parse(resp).map do |project|
+    JSON.parse(get('/api/v3/projects').body).map do |project|
       {
+        url: project['web_url'],
+        api_url: "https://gitlab.com/api/v3/projects/#{project['id']}",
         id: project['id'],
         name: project['path_with_namespace'],
         description: project['description'],
-        url: project['web_url'],
         followers: project['star_count'],
         origin: :gitlab
       }
@@ -19,5 +19,50 @@ module Gitlab
 
   def gitlab_url
     'https://gitlab.com/api/v3/'
+  end
+
+  def fetch_gitlab_project
+    project = JSON.parse(get(api_url).body)
+    builds = JSON.parse(get("/api/v3/projects/#{project['id']}/builds").body)
+    retval = {
+      name: project['path_with_namespace'],
+      description: project['description']
+    }
+    if builds.length.positive?
+      retval[:state] = builds[0]['status']
+      retval[:coverage] = builds[0]['coverage']
+    end
+    retval
+  end
+
+  def create_gitlab_webhook(url)
+    hook_data = {
+      url: url,
+      pipeline_events: true
+    }
+    post("#{api_url}/hooks", body: hook_data.to_json)
+  end
+
+  def delete_gitlab_webhook(url)
+    hooks = JSON.parse(get("#{api_url}/hooks").body)
+    hook = hooks.find { |h| h['url'] == url }
+    delete("#{api_url}/hooks/#{hook['id']}") if hook
+  end
+
+  def receive_gitlab_webhook(payload)
+    self.name = payload['project']['path_with_namespace']
+    self.description = payload['project']['description']
+    if payload['builds'].length.positive?
+      self.build_state = translate_status payload['builds'][0]['status']
+    end
+  end
+
+  def translate_status(state)
+    case state
+    when 'pending', 'running' then 'running'
+    when 'failed' then 'failed'
+    when 'success' then 'success'
+    else 'unknown'
+    end
   end
 end

--- a/app/models/concerns/oauth_client.rb
+++ b/app/models/concerns/oauth_client.rb
@@ -7,28 +7,28 @@ module OauthClient
     access_token.request(http_method, path, *arguments)
   end
 
-  def get(path, headers = {})
-    request(:get, path, headers)
+  def get(path, opts = {}, &block)
+    access_token.get(path, opts, &block)
   end
 
-  def head(path, headers = {})
-    request(:head, path, headers)
+  def head(path, opts = {}, &block)
+    access_token.head(path, opts, &block)
   end
 
-  def post(path, body = '', headers = {})
-    request(:post, path, body, headers)
+  def post(path, opts = {}, &block)
+    access_token.post(path, opts, &block)
   end
 
-  def put(path, body = '', headers = {})
-    request(:put, path, body, headers)
+  def put(path, opts = {}, &block)
+    access_token.put(path, opts, &block)
   end
 
-  def patch(path, body = '', headers = {})
-    request(:patch, path, body, headers)
+  def patch(path, opts = {}, &block)
+    access_token.patch(path, opts, &block)
   end
 
-  def delete(path, headers = {})
-    request(:delete, path, headers)
+  def delete(path, opts = {}, &block)
+    access_token.delete(path, opts, &block)
   end
 
   def client

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,5 +3,78 @@ class Project < ApplicationRecord
   validates :origin, presence: true
   validates :origin_id, presence: true
   validates :origin_id, uniqueness: { scope: :origin }
+  validates :api_url, presence: true
+  validates :api_url, uniqueness: true
   belongs_to :user
+
+  include OauthClient
+  include Gitlab
+  include Github
+
+  def refresh
+    return unless origin
+    meta = fetch_metadata
+    self.name = meta[:name]
+    self.build_state = meta[:state]
+    self.description = meta[:description]
+    self.coverage = meta[:coverage].to_f
+  end
+
+  def create_hook(url)
+    case provider.to_sym
+    when :github then create_github_webhook(url)
+    when :gitlab then create_gitlab_webhook(url)
+    else
+      raise "Unsupported OAuth provider #{provider}"
+    end
+  end
+
+  def delete_hook(url)
+    case provider.to_sym
+    when :github then delete_github_webhook(url)
+    when :gitlab then delete_gitlab_webhook(url)
+    else
+      raise "Unsupported OAuth provider #{provider}"
+    end
+  end
+
+  def receive_hook(payload)
+    case provider.to_sym
+    when :github then receive_github_webhook(payload)
+    when :gitlab then receive_gitlab_webhook(payload)
+    else
+      raise "Unsupported OAuth provider #{provider}"
+    end
+  end
+
+  private
+
+  def fetch_metadata
+    case provider.to_sym
+    when :github then fetch_github_project
+    when :gitlab then fetch_gitlab_project
+    else
+      raise "Unsupported OAuth provider #{provider}"
+    end
+  end
+
+  def token
+    account_link.token
+  end
+
+  def account_link
+    user.account_links.find_by(provider: origin)
+  end
+
+  def provider
+    origin
+  end
+
+  def provider_url
+    case provider
+    when 'gitlab' then gitlab_url
+    when 'github' then github_url
+    else super
+    end
+  end
 end

--- a/app/views/projects/_project.json.jbuilder
+++ b/app/views/projects/_project.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! project, :id, :name, :origin, :origin_id, :active, :coverage, :build_state, :created_at, :updated_at
+json.extract! project, :id, :name, :origin, :origin_id, :api_url, :active, :coverage, :build_state, :created_at, :updated_at
 json.url project_url(project, format: :json)

--- a/app/views/projects/setup.html.haml
+++ b/app/views/projects/setup.html.haml
@@ -15,12 +15,12 @@
             .btn.btn-success{ disabled: true, ng: { show: "projects['#{uniq_id}']['state'] == 'activating'" }}
               %span.fa.fa-spinner.fa-pulse.fa-fw
               Activating
-            .btn.btn-success{ ng: { show: "projects['#{uniq_id}']['state'] == 'inactive'", click: "activateProject('#{project[:origin]}', '#{project[:id]}')" }}
+            .btn.btn-success{ ng: { show: "projects['#{uniq_id}']['state'] == 'inactive'", click: "activateProject('#{project[:origin]}', '#{project[:id]}', '#{project[:api_url]}')" }}
               Activate
             .btn.btn-danger{ disabled: true, ng: { show: "projects['#{uniq_id}']['state'] == 'deactivating'" }}
               %span.fa.fa-spinner.fa-pulse.fa-fw
               Deactivating
-            .btn.btn-danger{ ng: { show: "projects['#{uniq_id}']['state'] == 'active'", click: "deactivateProject('#{project[:origin]}', '#{project[:id]}')" }}
+            .btn.btn-danger{ ng: { show: "projects['#{uniq_id}']['state'] == 'active'", click: "deactivateProject('#{project[:origin]}', '#{project[:id]}', '#{project[:api_url]}')" }}
               Deactivate
 
 - else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,12 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  activerecord:
+    attributes:
+      project:
+        origin_id:
+          one:   Origin ID
+          other: Origin IDs
+        api_url:
+          one:   API URL
+          other: API URLs

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   # resources
   resources :projects do
     get 'setup', on: :collection
+    post 'webhook', on: :collection
   end
 
   # static

--- a/db/migrate/20160905065436_add_api_url_to_projects.rb
+++ b/db/migrate/20160905065436_add_api_url_to_projects.rb
@@ -1,0 +1,5 @@
+class AddApiUrlToProjects < ActiveRecord::Migration[5.0]
+  def change
+    add_column :projects, :api_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160903190734) do
+ActiveRecord::Schema.define(version: 20160905065436) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 20160903190734) do
     t.string   "description"
     t.boolean  "active"
     t.integer  "origin_id"
+    t.string   "api_url"
     t.index ["user_id"], name: "index_projects_on_user_id", using: :btree
   end
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -4,7 +4,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   setup do
-    @project = projects(:project1)
+    @project = projects(:gitlab_project)
     # request.env['devise.mapping'] = Devise.mappings[:user]
   end
 
@@ -31,9 +31,19 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get setup' do
+    stub_request(:get, 'https://api.github.com/user/repos')
+      .to_return(body: [
+        { id: 123, full_name: 'github/project2' }
+      ].to_json)
+    stub_request(:get, 'https://gitlab.com/api/v3/projects')
+      .to_return(body: [
+        { id: 123, path_with_namespace: 'gitlab/project1' }
+      ].to_json)
     sign_in users(:alice)
     get setup_projects_path
     assert_response :success
+    assert_select 'a', 'gitlab/project1'
+    assert_select 'a', 'github/project2'
   end
 
   test 'should not get new logged out' do
@@ -62,14 +72,108 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_user_session_path
   end
 
-  test 'should create project' do
+  test 'should create github project' do
+    project_data = {
+      id: 123,
+      full_name: 'alice/test-repo',
+      description: 'this is a github repo'
+    }
+    statuses_data = [
+      {
+        state: 'failed'
+      },
+      {
+        state: 'success'
+      }
+    ]
+    stub_request(:get, 'https://api.github.com/repos/alice/test-repo')
+      .to_return(body: project_data.to_json)
+    stub_request(:get, 'https://api.github.com/repos/alice/test-repo/statuses/HEAD')
+      .to_return(body: statuses_data.to_json)
+    stub_request(:post, 'https://api.github.com/repos/alice/test-repo/hooks')
+      .with(body: {
+        name: 'appatite',
+        active: true,
+        events: [:status],
+        config: {
+          url: 'http://www.example.com/projects/webhook',
+          content_type: :json
+        }
+      }.to_json)
+      .to_return(status: 201)
+
     sign_in users(:alice)
     assert_difference('Project.count') do
       post projects_url,
            params: {
              project: {
-               origin: 'test',
+               origin: 'github',
+               origin_id: 1337,
+               api_url: 'https://api.github.com/repos/alice/test-repo'
+             }
+           }
+    end
+
+    assert_redirected_to project_url(Project.last)
+    assert_equal project_data[:full_name], Project.last.name
+    assert_equal project_data[:description], Project.last.description
+    assert_equal statuses_data[0][:state], Project.last.build_state
+  end
+
+  test 'should create gitlab project' do
+    project_data = {
+      id: 1337,
+      path_with_namespace: 'test-name',
+      state: 'test-state',
+      description: 'this is a gitlab repo'
+    }
+    builds_data = [
+      {
+        coverage: '42',
+        status: 'failed'
+      },
+      {
+        coverage: '30',
+        status: 'success'
+      }
+    ]
+    stub_request(:get, 'https://gitlab.com/api/v3/projects/1337')
+      .to_return(body: project_data.to_json)
+    stub_request(:get, 'https://gitlab.com/api/v3/projects/1337/builds')
+      .to_return(body: builds_data.to_json)
+    stub_request(:post, 'https://gitlab.com/api/v3/projects/1337/hooks')
+      .with(body: {
+        url: 'http://www.example.com/projects/webhook',
+        pipeline_events: true
+      }.to_json)
+      .to_return(status: 201)
+
+    sign_in users(:alice)
+    assert_difference('Project.count') do
+      post projects_url,
+           params: {
+             project: {
+               origin: 'gitlab',
+               origin_id: 1337,
+               api_url: 'https://gitlab.com/api/v3/projects/1337'
+             }
+           }
+    end
+
+    assert_redirected_to project_url(Project.last)
+    assert_equal project_data[:path_with_namespace], Project.last.name
+    assert_equal project_data[:description], Project.last.description
+    assert_equal builds_data[0][:status], Project.last.build_state
+  end
+
+  test 'should not create project without origin' do
+    sign_in users(:alice)
+    assert_no_difference('Project.count') do
+      post projects_url,
+           params: {
+             project: {
                origin_id: 123,
+               api_url: 'http://api.example.com/test',
                build_state: @project.build_state,
                coverage: @project.coverage,
                name: @project.name
@@ -77,7 +181,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
            }
     end
 
-    assert_redirected_to project_url(Project.last)
+    assert_response :success
+    assert_select 'li', "Origin can't be blank"
   end
 
   test 'should not show project logged out' do
@@ -113,6 +218,79 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to project_url(@project)
   end
 
+  test 'should activate github project' do
+    @project = projects(:github_project)
+    stub_request(:post, "#{@project.api_url}/hooks").to_return(status: 201)
+    @project.update_attribute(:active, false)
+
+    sign_in users(:alice)
+    patch project_url(@project), params: { project: { active: true } }
+
+    assert_redirected_to project_url(@project)
+    assert_requested :post, "#{@project.api_url}/hooks", body: {
+      name: 'appatite',
+      active: true,
+      events: [:status],
+      config: {
+        url: 'http://www.example.com/projects/webhook',
+        content_type: :json
+      }
+    }.to_json
+  end
+
+  test 'should activate gitlab project' do
+    stub_request(:post, "#{@project.api_url}/hooks").to_return(status: 201)
+    @project.update_attribute(:active, false)
+
+    sign_in users(:alice)
+    patch project_url(@project), params: { project: { active: true } }
+
+    assert_redirected_to project_url(@project)
+    assert_requested :post, "#{@project.api_url}/hooks", body: {
+      url: 'http://www.example.com/projects/webhook',
+      pipeline_events: true
+    }.to_json
+  end
+
+  test 'should deactivate github project' do
+    @project = projects(:github_project)
+    stub_request(:get, "#{@project.api_url}/hooks")
+      .to_return(body: [
+        { id: 123, config: { url: 'http://example.com/test' } },
+        { id: 42, config: { url: 'http://www.example.com/projects/webhook' } },
+        { id: 321, config: { url: 'http://test.io/foobar' } }
+      ].to_json)
+    stub_request(:delete, "#{@project.api_url}/hooks/42")
+      .to_return(status: 204)
+    @project.update_attribute(:active, true)
+
+    sign_in users(:alice)
+    patch project_url(@project), params: { project: { active: false } }
+
+    assert_redirected_to project_url(@project)
+    assert_requested :get, "#{@project.api_url}/hooks"
+    assert_requested :delete, "#{@project.api_url}/hooks/42"
+  end
+
+  test 'should deactivate gitlab project' do
+    stub_request(:get, "#{@project.api_url}/hooks")
+      .to_return(body: [
+        { id: 123, url: 'http://example.com/test' },
+        { id: 42, url: 'http://www.example.com/projects/webhook' },
+        { id: 321, url: 'http://test.io/foobar' }
+      ].to_json)
+    stub_request(:delete, "#{@project.api_url}/hooks/42")
+      .to_return(status: 204)
+    @project.update_attribute(:active, true)
+
+    sign_in users(:alice)
+    patch project_url(@project), params: { project: { active: false } }
+
+    assert_redirected_to project_url(@project)
+    assert_requested :get, "#{@project.api_url}/hooks"
+    assert_requested :delete, "#{@project.api_url}/hooks/42"
+  end
+
   test 'should not remove origin from project' do
     sign_in users(:alice)
     patch project_url(@project), params: { project: {
@@ -128,7 +306,16 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
       origin_id: nil
     } }
     assert_response :success
-    assert_select 'li', "Origin can't be blank"
+    assert_select 'li', "Origin ID can't be blank"
+  end
+
+  test 'should not remove api_url from project' do
+    sign_in users(:alice)
+    patch project_url(@project), params: { project: {
+      api_url: nil
+    } }
+    assert_response :success
+    assert_select 'li', "API URL can't be blank"
   end
 
   test 'should not destroy project logged out' do
@@ -139,12 +326,79 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_user_session_path
   end
 
-  test 'should destroy project' do
+  test 'should destroy github project' do
+    @project = projects(:github_project)
+    stub_request(:get, "#{@project.api_url}/hooks")
+      .to_return(body: [
+        { id: 123, config: { url: 'http://example.com/test' } },
+        { id: 42, config: { url: 'http://www.example.com/projects/webhook' } },
+        { id: 321, config: { url: 'http://test.io/foobar' } }
+      ].to_json)
+    stub_request(:delete, "#{@project.api_url}/hooks/42")
+      .to_return(status: 204)
     sign_in users(:alice)
     assert_difference('Project.count', -1) do
       delete project_url(@project)
     end
 
     assert_redirected_to projects_url
+    assert_requested :get, "#{@project.api_url}/hooks"
+    assert_requested :delete, "#{@project.api_url}/hooks/42"
+  end
+
+  test 'should destroy gitlab project' do
+    stub_request(:get, "#{@project.api_url}/hooks")
+      .to_return(body: [
+        { id: 123, url: 'http://example.com/test' },
+        { id: 42, url: 'http://www.example.com/projects/webhook' },
+        { id: 321, url: 'http://test.io/foobar' }
+      ].to_json)
+    stub_request(:delete, "#{@project.api_url}/hooks/42")
+      .to_return(status: 204)
+    sign_in users(:alice)
+    assert_difference('Project.count', -1) do
+      delete project_url(@project)
+    end
+
+    assert_redirected_to projects_url
+    assert_requested :get, "#{@project.api_url}/hooks"
+    assert_requested :delete, "#{@project.api_url}/hooks/42"
+  end
+
+  test 'should handle github hook' do
+    @project = projects(:github_project)
+    hook_data = {
+      state: 'pending',
+      repository: {
+        url: @project.api_url,
+        full_name: 'alice/new-name',
+        description: 'new description here'
+      }
+    }.to_json
+    post webhook_projects_url, params: hook_data, headers: { 'X-GitHub-Event' => 'status' }
+    assert_response :success
+    assert_equal 'alice/new-name', Project.find(@project.id).name
+    assert_equal 'running', Project.find(@project.id).build_state
+  end
+
+  test 'should handle gitlab hook' do
+    hook_data = {
+      builds: [
+        {
+          status: 'running'
+        },
+        {
+          status: 'success'
+        }
+      ],
+      project: {
+        id: 123,
+        path_with_namespace: 'alice/new-name',
+        description: 'new description here'
+      }
+    }.to_json
+    post webhook_projects_url, params: hook_data
+    assert_equal 'alice/new-name', Project.find(@project.id).name
+    assert_equal 'running', Project.find(@project.id).build_state
   end
 end

--- a/test/fixtures/account_links.yml
+++ b/test/fixtures/account_links.yml
@@ -1,6 +1,12 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 link1:
-  provider: TestProvider
+  provider: github
   uid: test
   user: alice
+  token: mytoken
+link2:
+  provider: gitlab
+  uid: test
+  user: alice
+  token: mytoken

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -1,17 +1,21 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-project1:
+gitlab_project:
   name: Project1
   origin: gitlab
   origin_id: 123
+  api_url: https://gitlab.com/api/v3/projects/123
   user: alice
   coverage: 1
+  active: true
   build_state: success
 
-project2:
+github_project:
   name: Project2
   origin: github
   origin_id: 123
+  api_url: https://api.github.com/alice/test-repo
   user: alice
+  active: true
   coverage: 95
   build_state: failed

--- a/test/models/account_link_test.rb
+++ b/test/models/account_link_test.rb
@@ -44,7 +44,7 @@ class AccountLinkTest < ActiveSupport::TestCase
   end
 
   test 'should get gitlab projects' do
-    stub_request(:get, 'https://gitlab.com/api/v3/projects?access_token=mytoken')
+    stub_request(:get, 'https://gitlab.com/api/v3/projects')
       .to_return(body: [{ id: 42 }, { id: 1337 }].to_json)
     link = AccountLink.new(
       user: users(:alice),

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -5,6 +5,7 @@ class ProjectTest < ActiveSupport::TestCase
     project = Project.new(
       name: 'test',
       origin_id: 123,
+      api_url: 'http://api.com/test',
       user: users(:bob)
     )
     assert !project.save, 'Saved without origin'
@@ -14,6 +15,7 @@ class ProjectTest < ActiveSupport::TestCase
     project = Project.new(
       name: 'test',
       origin: 'test',
+      api_url: 'http://api.com/test',
       user: users(:bob)
     )
     assert !project.save, 'Saved without origin_id'
@@ -23,9 +25,20 @@ class ProjectTest < ActiveSupport::TestCase
     project = Project.new(
       name: 'test',
       origin: 'test',
-      origin_id: 123
+      origin_id: 123,
+      api_url: 'http://api.com/test'
     )
     assert !project.save, 'Saved without user'
+  end
+
+  test 'should not create project without api_url' do
+    project = Project.new(
+      name: 'test',
+      origin: 'test',
+      origin_id: 123,
+      user: users(:bob)
+    )
+    assert !project.save, 'Saved without api_url'
   end
 
   test 'should not create project with existing origin and origin_id' do
@@ -42,9 +55,202 @@ class ProjectTest < ActiveSupport::TestCase
     project = Project.new(
       name: 'test',
       origin: 'test',
+      api_url: 'http://api.com/test',
       origin_id: 123,
       user: users(:bob)
     )
     assert project.save, 'Did not save project'
+  end
+
+  test 'should refresh github project meta data' do
+    project_data = {
+      id: 123,
+      full_name: 'alice/test-repo',
+      description: 'this is a github repo'
+    }
+    statuses_data = [
+      {
+        state: 'failed'
+      },
+      {
+        state: 'success'
+      }
+    ]
+    stub_request(:get, 'https://api.github.com/repos/alice/test-repo')
+      .to_return(body: project_data.to_json)
+    stub_request(:get, 'https://api.github.com/repos/alice/test-repo/statuses/HEAD')
+      .to_return(body: statuses_data.to_json)
+
+    project = Project.new(
+      api_url: 'https://api.github.com/repos/alice/test-repo',
+      origin: 'github',
+      user: users(:alice)
+    )
+    project.refresh
+
+    assert_equal project_data[:full_name], project.name
+    assert_equal statuses_data[0][:state], project.build_state
+    assert_equal project_data[:description], project.description
+  end
+
+  test 'should refresh gitlab project meta data' do
+    project_data = {
+      id: 123,
+      path_with_namespace: 'test-name',
+      state: 'test-state',
+      description: 'this is a gitlab repo'
+    }
+    builds_data = [
+      {
+        coverage: '42',
+        status: 'failed'
+      },
+      {
+        coverage: '30',
+        status: 'success'
+      }
+    ]
+    stub_request(:get, 'https://gitlab.com/api/v3/projects/123')
+      .to_return(body: project_data.to_json)
+    stub_request(:get, 'https://gitlab.com/api/v3/projects/123/builds')
+      .to_return(body: builds_data.to_json)
+
+    project = Project.new(
+      api_url: 'https://gitlab.com/api/v3/projects/123',
+      origin: 'gitlab',
+      user: users(:alice)
+    )
+    project.refresh
+
+    assert_equal project_data[:path_with_namespace], project.name
+    assert_equal project_data[:description], project.description
+    assert_equal builds_data[0][:status], project.build_state
+    assert_equal builds_data[0][:coverage], project.coverage.to_s
+  end
+
+  test 'should create github webhook' do
+    stub_request(:post, 'https://api.github.com/repos/alice/test-repo/hooks')
+      .with(body: {
+        name: 'appatite',
+        active: true,
+        events: [:status],
+        config: {
+          url: 'http://example.com/projects/webhook',
+          content_type: :json
+        }
+      }.to_json)
+      .to_return(status: 201)
+
+    project = Project.new(
+      api_url: 'https://api.github.com/repos/alice/test-repo',
+      origin: 'github',
+      user: users(:alice)
+    )
+    assert project.create_hook('http://example.com/projects/webhook'),
+           'Did not create webhook'
+  end
+
+  test 'should delete github webhook' do
+    stub_request(:get, 'https://api.github.com/repos/alice/test-repo/hooks')
+      .to_return(body: [
+        { id: 123, config: { url: 'http://example.com/test' } },
+        { id: 42, config: { url: 'http://example.com/projects/webhook' } },
+        { id: 321, config: { url: 'http://test.io/foobar' } }
+      ].to_json)
+    stub_request(:delete, 'https://api.github.com/repos/alice/test-repo/hooks/42')
+      .to_return(status: 204)
+
+    project = Project.new(
+      api_url: 'https://api.github.com/repos/alice/test-repo',
+      origin: 'github',
+      user: users(:alice)
+    )
+    assert project.delete_hook('http://example.com/projects/webhook'),
+           'Did not delete webhook'
+  end
+
+  test 'should create gitlab webhook' do
+    stub_request(:post, 'https://gitlab.com/api/v3/projects/123/hooks')
+      .with(body: {
+        url: 'http://example.com/projects/webhook',
+        pipeline_events: true
+      }.to_json)
+      .to_return(status: 201)
+
+    project = Project.new(
+      api_url: 'https://gitlab.com/api/v3/projects/123',
+      origin: 'gitlab',
+      user: users(:alice)
+    )
+    assert project.create_hook('http://example.com/projects/webhook'),
+           'Did not create webhook'
+  end
+
+  test 'should delete gitlab webhook' do
+    stub_request(:get, 'https://gitlab.com/api/v3/projects/123/hooks')
+      .to_return(body: [
+        { id: 123, url: 'http://example.com/test' },
+        { id: 42, url: 'http://example.com/projects/webhook' },
+        { id: 321, url: 'http://test.io/foobar' }
+      ].to_json)
+    stub_request(:delete, 'https://gitlab.com/api/v3/projects/123/hooks/42')
+      .to_return(status: 204)
+
+    project = Project.new(
+      api_url: 'https://gitlab.com/api/v3/projects/123',
+      origin: 'gitlab',
+      user: users(:alice)
+    )
+    assert project.delete_hook('http://example.com/projects/webhook'),
+           'Did not delete webhook'
+  end
+
+  test 'should receive github status webhook' do
+    project = Project.new(
+      api_url: 'https://api.github.com/repos/alice/test-repo',
+      origin: 'github',
+      user: users(:alice)
+    )
+    hook_data = {
+      state: 'pending',
+      repository: {
+        full_name: 'alice/new-name',
+        description: 'new description here'
+      }
+    }.to_json
+
+    project.receive_hook(JSON.parse(hook_data))
+
+    assert_equal 'alice/new-name', project.name
+    assert_equal 'running', project.build_state
+    assert_equal 'new description here', project.description
+  end
+
+  test 'should receive gitlab pipeline webhook' do
+    project = Project.new(
+      api_url: 'https://gitlab.com/api/v3/projects/123',
+      origin: 'gitlab',
+      user: users(:alice)
+    )
+    hook_data = {
+      builds: [
+        {
+          status: 'running'
+        },
+        {
+          status: 'success'
+        }
+      ],
+      project: {
+        path_with_namespace: 'alice/new-name',
+        description: 'new description here'
+      }
+    }.to_json
+
+    project.receive_hook(JSON.parse(hook_data))
+
+    assert_equal 'alice/new-name', project.name
+    assert_equal 'running', project.build_state
+    assert_equal 'new description here', project.description
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,18 @@ class ActiveSupport::TestCase
   end
 
   def teardown
+    WebMock.reset!
+    WebMock.allow_net_connect!
+  end
+end
+
+class ActionDispatch::IntegrationTest
+  def setup
+    WebMock.disable_net_connect!(allow_localhost: true)
+  end
+
+  def teardown
+    WebMock.reset!
     WebMock.allow_net_connect!
   end
 end


### PR DESCRIPTION
Register a webhook in Gitlab and Github for repositories that are
activated/created, and remove it when they are deactivated/removed.

Add method `Project#refresh` to pull in meta data from Gitlab and
Github, and `Project#receive_hook` for parsing webhook payload.

Fixes #6 #24