### PR TITLE
Rename Github webhook to 'web'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,9 @@ group :test do
 
   # Use WebMock to stub web request
   gem 'webmock'
+
+  # Use Mocha for stubbing and mocking in Ruby tests
+  gem 'mocha'
 end
 
 # Gemified versions of Bower packages for frontend

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,12 +98,15 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    metaclass (0.0.4)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
     multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
@@ -249,6 +252,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
+  mocha
   oauth2
   omniauth-github
   omniauth-gitlab

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 [![Build Status](https://travis-ci.org/ephracis/appatite.svg?branch=master)](https://travis-ci.org/ephracis/appatite)
 [![Code Climate](https://codeclimate.com/github/ephracis/appatite/badges/gpa.svg)](https://codeclimate.com/github/ephracis/appatite)
 [![Test Coverage](https://codeclimate.com/github/ephracis/appatite/badges/coverage.svg)](https://codeclimate.com/github/ephracis/appatite/coverage)
-[![Stories in progress](https://badge.waffle.io/ephracis/appatite.svg?label=in%20progress&title=in%20progress)](http://waffle.io/ephracis/appatite)
 [![GitHub license](https://img.shields.io/badge/license-GPLv3-blue.svg)](https://raw.githubusercontent.com/ephracis/appatite/master/LICENSE)
 [![Issue Stats](http://www.issuestats.com/github/ephracis/appatite/badge/pr?style=flat)](http://www.issuestats.com/github/ephracis/appatite)
 [![Issue Stats](http://www.issuestats.com/github/ephracis/appatite/badge/issue?style=flat)](http://www.issuestats.com/github/ephracis/appatite)
+[![Stories in progress](https://badge.waffle.io/ephracis/appatite.svg?label=issues%20in%20progress&title=in%20progress)](http://waffle.io/ephracis/appatite)
 
 # Welcome to Appatite
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,6 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   after_action :set_csrf_cookie_for_ng
-  before_action :fill_project_metadata
 
   # Ensure that Angular AJAX requests carry the authenticity token
   def set_csrf_cookie_for_ng
@@ -24,26 +23,5 @@ class ApplicationController < ActionController::Base
   # Extend the CSRF verification to allow Angular AJAX calls
   def verified_request?
     super || valid_authenticity_token?(session, request.headers['X-XSRF-TOKEN'])
-  end
-
-  # TODO: Temporary method for filling out api_url on projects
-  def fill_project_metadata
-    if Project.where(api_url: nil).any?
-      projects = []
-      User.all.each { |u| u.account_links.each { |l| projects += l.projects } }
-      logger.info projects.to_yaml
-      projects.each do |hash|
-        p = Project.find_by(
-          origin: hash[:origin],
-          origin_id: hash[:id]
-        )
-        logger.info "Project: #{hash[:name]}"
-        logger.info p.inspect
-        p.update_attributes!(
-          name: hash[:name],
-          api_url: hash[:api_url]
-        ) if p
-      end
-    end
   end
 end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -3,14 +3,5 @@ class StaticController < ApplicationController
   end
 
   def about
-    l = current_user.account_links.find_by(provider: :github)
-    project = JSON.parse(l.send(:get, 'https://api.github.com/repos/ephracis/appatite').body)
-    name = project['full_name']
-    statuses = JSON.parse(l.send(:get, "/repos/#{name}/statuses/HEAD").body)
-    if statuses.length.positive?
-      render json: statuses[0]['state']
-    else
-      render json: { error: 'no statuses' }
-    end
   end
 end

--- a/app/models/concerns/github.rb
+++ b/app/models/concerns/github.rb
@@ -34,7 +34,7 @@ module Github
 
   def create_github_webhook(url)
     hook_data = {
-      name: 'appatite',
+      name: 'web',
       active: true,
       events: [:status],
       config: {

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -92,7 +92,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
       .to_return(body: statuses_data.to_json)
     stub_request(:post, 'https://api.github.com/repos/alice/test-repo/hooks')
       .with(body: {
-        name: 'appatite',
+        name: 'web',
         active: true,
         events: [:status],
         config: {
@@ -228,7 +228,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to project_url(@project)
     assert_requested :post, "#{@project.api_url}/hooks", body: {
-      name: 'appatite',
+      name: 'web',
       active: true,
       events: [:status],
       config: {

--- a/test/models/account_link_test.rb
+++ b/test/models/account_link_test.rb
@@ -70,4 +70,43 @@ class AccountLinkTest < ActiveSupport::TestCase
     assert_equal 42, link.projects[0][:id]
     assert_equal 1337, link.projects[1][:id]
   end
+
+  test 'should raise exception on unsupported provider' do
+    link = AccountLink.new(provider: 'test')
+    assert_raises RuntimeError do
+      link.send(:provider_url)
+    end
+  end
+
+  test 'should send oauth request' do
+    OAuth2::AccessToken.any_instance.expects(:request).with(
+      '/test/path', headers: { 'Foo' => 'Bar' }
+    )
+    link = AccountLink.new(provider: 'gitlab')
+    link.request('/test/path', headers: { 'Foo' => 'Bar' })
+  end
+
+  test 'should send oauth head request' do
+    OAuth2::AccessToken.any_instance.expects(:head).with(
+      '/test/path', headers: { 'Foo' => 'Bar' }
+    )
+    link = AccountLink.new(provider: 'gitlab')
+    link.head('/test/path', headers: { 'Foo' => 'Bar' })
+  end
+
+  test 'should send oauth put request' do
+    OAuth2::AccessToken.any_instance.expects(:put).with(
+      '/test/path', headers: { 'Foo' => 'Bar' }
+    )
+    link = AccountLink.new(provider: 'gitlab')
+    link.put('/test/path', headers: { 'Foo' => 'Bar' })
+  end
+
+  test 'should send oauth patch request' do
+    OAuth2::AccessToken.any_instance.expects(:patch).with(
+      '/test/path', headers: { 'Foo' => 'Bar' }
+    )
+    link = AccountLink.new(provider: 'gitlab')
+    link.patch('/test/path', headers: { 'Foo' => 'Bar' })
+  end
 end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -131,7 +131,7 @@ class ProjectTest < ActiveSupport::TestCase
   test 'should create github webhook' do
     stub_request(:post, 'https://api.github.com/repos/alice/test-repo/hooks')
       .with(body: {
-        name: 'appatite',
+        name: 'web',
         active: true,
         events: [:status],
         config: {
@@ -252,5 +252,41 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal 'alice/new-name', project.name
     assert_equal 'running', project.build_state
     assert_equal 'new description here', project.description
+  end
+
+  test 'should raise when creating hook on unsupported provider' do
+    project = Project.new(
+      origin: 'test'
+    )
+    assert_raises RuntimeError do
+      project.create_hook('test')
+    end
+  end
+
+  test 'should raise when deleting hook on unsupported provider' do
+    project = Project.new(
+      origin: 'test'
+    )
+    assert_raises RuntimeError do
+      project.delete_hook('test')
+    end
+  end
+
+  test 'should raise when fetching metadata from unsupported provider' do
+    project = Project.new(
+      origin: 'test'
+    )
+    assert_raises RuntimeError do
+      project.send(:fetch_metadata)
+    end
+  end
+
+  test 'should raise when getting url for unsupported provider' do
+    project = Project.new(
+      origin: 'test'
+    )
+    assert_raises RuntimeError do
+      project.send(:provider_url)
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
 require 'webmock/minitest'
+require 'mocha/mini_test'
 
 OmniAuth.config.test_mode = true
 


### PR DESCRIPTION
Github requires us to use 'web' as the name for our webhook as any
other name is reserved for known services.

This commit also adds a bunch of unit tests and some cleanup of
temporary code in an effort to increase code coverage.

Fixes #36