### PR TITLE
Push out webhook changes to clients in real time

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub license](https://img.shields.io/badge/license-GPLv3-blue.svg)](https://raw.githubusercontent.com/ephracis/appatite/master/LICENSE)
 [![Issue Stats](http://www.issuestats.com/github/ephracis/appatite/badge/pr?style=flat)](http://www.issuestats.com/github/ephracis/appatite)
 [![Issue Stats](http://www.issuestats.com/github/ephracis/appatite/badge/issue?style=flat)](http://www.issuestats.com/github/ephracis/appatite)
-[![Stories in progress](https://badge.waffle.io/ephracis/appatite.svg?label=issues%20in%20progress&title=in%20progress)](http://waffle.io/ephracis/appatite)
+[![Issues in progress](https://badge.waffle.io/ephracis/appatite.svg?label=in%20progress&title=issues%20in%20progress)](http://waffle.io/ephracis/appatite)
 
 # Welcome to Appatite
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,5 @@ Vagrant.configure(2) do |config|
      bin/rails db:create
      set -e
      bin/rails db:migrate
-     bin/rails server -b 0.0.0.0 -p 3000
   SHELL
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -38,6 +38,7 @@ class ProjectsController < ApplicationController
     project = Project.find_by(api_url: api_url)
     project.receive_hook(payload) if project
     if project && project.save
+      ProjectChannel.broadcast_to project.user, project
       head :ok
     else
       format.json { render json: project.errors, status: :unprocessable_entity }


### PR DESCRIPTION
Whenever a webhook payload is recieved the changes are pushed out
to clients in real time, updating the web page in the browsers
without the need for a page refresh.

Also, remove the server command in Vagrantfile, leaving that up
to the user. This means that provisioning will succeeed as it will
actually reach a proper end.

Fixes #37