### PR TITLE
Show build badge when status is set to 'unknown'

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ You can now access the machine:
 
 Run the tests:
 
-    rubocop -aD # code linting with automatic correction
-    bin/rails test # ruby unit and integration tests
+```bash
+rubocop -aD # code linting with automatic correction
+bin/rails test # ruby unit and integration tests
+```
 
 Start the server:
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -21,6 +21,7 @@ class Project < ApplicationRecord
   end
 
   def create_hook(url)
+    return if Rails.env.development?
     case provider.to_sym
     when :github then create_github_webhook(url)
     when :gitlab then create_gitlab_webhook(url)
@@ -30,6 +31,7 @@ class Project < ApplicationRecord
   end
 
   def delete_hook(url)
+    return if Rails.env.development?
     case provider.to_sym
     when :github then delete_github_webhook(url)
     when :gitlab then delete_gitlab_webhook(url)

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -22,7 +22,7 @@
 
   .form-group
     = f.label :build_state
-    = f.select :build_state, [['Success', :success], ['Failed', :failed], ['Running', :running]], {}, class: 'form-control'
+    = f.select :build_state, [['Success', :success], ['Failed', :failed], ['Running', :running], ['Unknown', :unknown], ['Empty', '']], {}, class: 'form-control'
 
   .actions
     = f.submit class: 'btn btn-primary'

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -21,7 +21,7 @@
             Success
           .label.label-danger{ ng: { show: "projects['#{uniq_id}']['build_state'] == 'failed'" }}
             Failed
-          .label.label-default{ ng: { show: "projects['#{uniq_id}']['build_state'] == ''" }}
+          .label.label-default{ ng: { show: "['', 'unknown'].indexOf(projects['#{uniq_id}']['build_state']) > -1" }}
             Unknown
           .label.label-primary{ ng: { show: "projects['#{uniq_id}']['build_state'] == 'running'" }}
             Running


### PR DESCRIPTION
The Unknown build badge is currently only shown when the build state
is an empty string. This shows it when the state is set to `unknown`
as well.

Fixes #44