### PR TITLE
Fix parsing of a successful build status on Github

### DIFF
--- a/app/models/concerns/github.rb
+++ b/app/models/concerns/github.rb
@@ -60,7 +60,7 @@ module Github
   def translate_state(state)
     case state
     when 'pending' then 'running'
-    when 'passed' then 'success'
+    when 'success' then 'success'
     when 'failed' then 'failed'
     else 'unknown'
     end


### PR DESCRIPTION
Turns out a successful build status on Github is `success` and not
`passed`. :smile: