### PR TITLE
Create admin overview with recent projects and users

### DIFF
--- a/app/assets/stylesheets/main.sass
+++ b/app/assets/stylesheets/main.sass
@@ -18,3 +18,6 @@ h2
   overflow: hidden
   text-overflow: ellipsis
   white-space: nowrap
+
+.spacer
+  height: 2em

--- a/app/assets/stylesheets/media-object.sass
+++ b/app/assets/stylesheets/media-object.sass
@@ -1,0 +1,8 @@
+.media
+  .media-left
+    vertical-align: middle
+    img
+      margin: 0 .4em
+  .media-body
+    h5
+      margin: .1em 0 .3em

--- a/app/assets/stylesheets/nav.sass
+++ b/app/assets/stylesheets/nav.sass
@@ -1,0 +1,15 @@
+.nav-pills
+  li
+    a
+      border-radius: 0
+      &:hover
+        background-color: transparent
+        border-bottom: 2px solid #eee
+  li.active
+    a
+      background-color: transparent
+      color: #337ab7
+      border-bottom: 2px solid #337ab7
+      &:hover
+        background-color: transparent
+        color: #337ab7

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -3,14 +3,16 @@ class AdminController < ApplicationController
   before_action :ensure_admin
 
   def overview
+    @recent_users = User.limit(3).order(created_at: :desc)
+    @recent_projects = Project.limit(3).order(created_at: :desc)
   end
 
   def users
-    @users = User.limit(10).order(:created_at)
+    @users = User.order(created_at: :desc)
   end
 
   def projects
-    @projects = Project.all
+    @projects = Project.order(created_at: :desc)
   end
 
   def settings

--- a/app/views/admin/overview.html.haml
+++ b/app/views/admin/overview.html.haml
@@ -1,2 +1,24 @@
-%h1 Overview
-%p Overview goes here
+.row
+  .col-xs-6.text-center
+    %h2= User.count
+    .lead= 'User'.pluralize(User.count)
+  .col-xs-6.text-center
+    %h2= Project.count
+    .lead= 'Project'.pluralize(Project.count)
+.row
+  .col-md-6
+    %h4 Recent registrations
+    - if @recent_users.blank?
+      .alert.alert-info
+        No users found
+    - else
+      = render @recent_users
+    .spacer
+  .col-md-6
+    %h4 Recent projects
+    - if @recent_projects.blank?
+      .alert.alert-info
+        No projects found
+    - else
+      = render @recent_projects
+    .spacer

--- a/app/views/projects/_project.haml
+++ b/app/views/projects/_project.haml
@@ -1,0 +1,10 @@
+.media
+  .media-left
+    = link_to project_url(project) do
+      = content_tag :span, '', class: "fa fa-3x fa-fw fa-#{project.origin}"
+  .media-body
+    %h5= project.name
+    %span.fa.fa-calendar
+    Created
+    = time_ago_in_words(project.created_at)
+    ago

--- a/app/views/users/_user.haml
+++ b/app/views/users/_user.haml
@@ -1,0 +1,13 @@
+.media
+  .media-left
+    = link_to user_path(user) do
+      - if user.image.blank?
+        %span.fa.fa-3x.fa-fw.fa-user
+      - else
+        = image_tag user.image, class: 'img-circle', width: 42
+  .media-body
+    %h5= user.name
+    %span.fa.fa-calendar
+    Joined
+    = time_ago_in_words(user.created_at)
+    ago


### PR DESCRIPTION
Fill the admin overview page with the total number of users and
projects, along with a list of the three most recent user registrations
and created projects.

Style the navbar pills so they instead of a background color has an
underline.

Fixes #15