### PR TITLE
Create a pricing page

### DIFF
--- a/app/assets/stylesheets/navbar.sass
+++ b/app/assets/stylesheets/navbar.sass
@@ -1,0 +1,49 @@
+.navbar-appatite
+  background-color: #337ab7
+  border-bottom: 1px solid darken(#337ab7, 10%)
+  border-radius: 0
+  border-right: 0
+  border-left: 0
+
+  .navbar-brand
+    color: rgba(255,255,255,0.8)
+    font-weight: 100
+    &:hover, &:focus
+      color: white
+
+  .navbar-toggle
+    border-color: rgba(255,255,255,0.9)
+    &:hover, &:focus
+      background-color: rgba(255,255,255,0.2)
+    .icon-bar
+      background-color: rgba(255,255,255,0.8)
+  
+  .navbar-collapse.in
+    ul.dropdown-menu > li > a
+      color: rgba(255,255,255,0.8)
+      &:hover
+        color: white
+
+  .navbar-nav > li > a
+    text-transform: uppercase
+    letter-spacing: 2px
+    font-size: 0.8em
+    color: rgba(255,255,255,0.7)
+    &:hover, &:focus
+      color: white
+    .fa
+      font-size: 1.7em
+  .navbar-nav > .open > a
+    color: white
+    background-color: lighten(#337ab7, 10%)
+    &:hover, &:focus
+      color: white
+      background-color: lighten(#337ab7, 10%)
+
+  .dropdown-avatar
+    .dropdown-toggle
+      padding-top: 12px
+      padding-bottom: 12px
+      img
+        height: 25px
+    

--- a/app/assets/stylesheets/panel.sass
+++ b/app/assets/stylesheets/panel.sass
@@ -1,0 +1,14 @@
+.panel-featured
+  .panel-heading
+    font-size: 1.3em
+  
+  .panel-headline
+    font-size: 54px
+    .currency
+      position: relative
+      font-size: 27px
+      top: -16px
+      right: -10px
+
+  .panel-action
+    padding: 3em 0 2em

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -2,7 +2,6 @@ class StaticController < ApplicationController
   def index
   end
 
-  def about
-    sign_in(:user, User.first) if Rails.env.development?
+  def pricing
   end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,7 +10,7 @@
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
 
   %body
-    %nav.navbar.navbar-default
+    %nav.navbar.navbar-default.navbar-appatite
       .container-fluid
         .navbar-header
           %button.navbar-toggle.collapsed{ type: 'button', data: { toggle: 'collapse', target: "#navbar-collapse-1" } }
@@ -25,15 +25,23 @@
         .collapse.navbar-collapse#navbar-collapse-1
           %ul.nav.navbar-nav
             %li= link_to 'Projects', projects_path
-            %li= link_to 'About', '/about'
-            - if admin?
-              %li= link_to 'Admin', admin_overview_path
+            %li= link_to 'Pricing', pricing_path
 
           %ul.nav.navbar-nav.navbar-right
+            - if admin?
+              %li
+                = link_to admin_overview_path do
+                  %span.hidden-xs
+                    %span.fa.fa-wrench.fa-fw
+                  %span.visible-xs
+                    Admin
             - if user_signed_in?
-              %li.dropdown
+              %li.dropdown.dropdown-avatar
                 %a.dropdown-toggle{ href: '#', data: { toggle: 'dropdown' }, role: 'button', aria: { haspopup: true, expanded: false }}
-                  = current_user.name
+                  - if current_user.image.blank?
+                    %span.fa.fa-fw.fa-user
+                  - else
+                    = image_tag current_user.image, class: 'img-circle'
                   %span.caret
                 %ul.dropdown-menu
                   %li

--- a/app/views/static/about.html.haml
+++ b/app/views/static/about.html.haml
@@ -1,2 +1,0 @@
-.text-center
-  %p This is the about page

--- a/app/views/static/index.html.haml
+++ b/app/views/static/index.html.haml
@@ -6,7 +6,7 @@
     You just realized you need to put it on a dedicated screen near both developers
     and project managers.
   %p
-    = link_to 'Get started', new_project_path, class: 'btn btn-primary btn-lg'
+    = link_to 'Get started', setup_projects_path, class: 'btn btn-primary btn-lg'
 
 .container.text-center
 

--- a/app/views/static/pricing.haml
+++ b/app/views/static/pricing.haml
@@ -1,0 +1,70 @@
+.text-center
+  %h1 Choose your Appatite
+  .lead
+    A beautiful way to visualize your projects with a quick glance
+
+.container
+  .row
+    .col-md-4.text-center
+      .panel.panel-default.panel-featured
+        .panel-heading
+          Open Source
+        .panel-body.text-center
+          %h2.panel-headline Free
+          Free forever for open source hobbyists
+          .panel-action
+            %a.btn.btn-md.btn-primary Get started
+        %ul.list-group.text-left
+          %li.list-group-item
+            %span.fa.fa-check
+            Up to 3 public repositories
+          %li.list-group-item
+            %span.fa.fa-check
+            Both Github and Gitlab
+          %li.list-group-item
+            %span.fa.fa-check
+            Something, something
+
+    .col-md-4.text-center
+      .panel.panel-success.panel-featured
+        .panel-heading
+          Standard
+        .panel-body.text-center
+          %h2.panel-headline
+            %span.currency $
+            1/mo
+          Unlimited public repositories
+          .panel-action
+            %a.btn.btn-md.btn-success Buy Now
+        %ul.list-group.text-left
+          %li.list-group-item
+            %span.fa.fa-check
+            Unlimited public repositories
+          %li.list-group-item
+            %span.fa.fa-check
+            Up to 3 private repositories
+          %li.list-group-item
+            %span.fa.fa-check
+            Something, something
+
+    .col-md-4.text-center
+      .panel.panel-default.panel-featured
+        .panel-heading
+          Premium
+        .panel-body.text-center
+          %h2.panel-headline
+            %span.currency $
+            9/mo
+          Unlimited private repositories
+          .panel-action
+            %a.btn.btn-md.btn-primary Buy Now
+        %ul.list-group.text-left
+          %li.list-group-item
+            %span.fa.fa-check
+            Unlimited private repositories
+          %li.list-group-item
+            %span.fa.fa-check
+            Github Enterprise
+          %li.list-group-item
+            %span.fa.fa-check
+            Gitlab CE and EE

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+
+  # admin
   get 'admin/overview'
   get 'admin/users'
   get 'admin/projects'
@@ -24,6 +26,6 @@ Rails.application.routes.draw do
   end
 
   # static
-  get '/about', to: 'static#about'
+  get '/pricing', to: 'static#pricing'
   root to: 'static#index'
 end


### PR DESCRIPTION
Rename the `about` page to `pricing` and add description of the three
pricing tiers with their features and the price.

Style the navbar with a custom blue color and white text, and
replace the logged in user's name with their avatar instead. Similarly,
replace the Admin link with an icon (only non-mobile) and move it to
the right.

Fixes #26