### PR TITLE
Create user profile settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # Welcome to Appatite
 
-This is the project for the [Appatite website](appatite.herokuapp.com).
+This is the project for the [Appatite website](http://appatite.herokuapp.com).
 
 ## Get started
 

--- a/app/assets/stylesheets/form.sass
+++ b/app/assets/stylesheets/form.sass
@@ -1,0 +1,7 @@
+.form-section
+  margin-bottom: 1em
+  h2
+    margin-top: 0
+
+.form-avatar
+  margin-bottom: 1em

--- a/app/controllers/users/profile_controller.rb
+++ b/app/controllers/users/profile_controller.rb
@@ -1,7 +1,7 @@
 class Users::ProfileController < Devise::RegistrationsController
   before_action -> { authenticate_user! force: true }
   before_action :ensure_admin, only: :toggle_admin
-  before_action :set_resource
+  before_action :set_user
 
   # Toggle admin flag on a user
   def toggle_admin
@@ -21,9 +21,25 @@ class Users::ProfileController < Devise::RegistrationsController
     @user = current_user unless current_user.admin?
   end
 
+  def update
+    @user = current_user.admin? ? User.find(params[:id]) : current_user
+    if @user.update(user_params)
+      redirect_to @user, notice: 'Profile was successfully updated.'
+    else
+      render :edit
+    end
+  end
+
   private
 
-  def set_resource
+  def set_user
     @user = User.find params[:id]
+  end
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def user_params
+    params.require(:user).permit(
+      :name, :image, :email
+    )
   end
 end

--- a/app/views/users/profile/edit.html.haml
+++ b/app/views/users/profile/edit.html.haml
@@ -1,5 +1,43 @@
-.text-center
-  %h1 Edit profile
-  %p
-    Here we will put some stuff for editing the profile and account settings for
-    = @user.name
+.container
+  .row
+    .col-lg-3.form-section
+      %h2 Main settings
+      This information will appear on your profile.
+    .col-lg-9
+      = form_for(@user) do |f|
+        - if @user.errors.any?
+          #error_explanation.alert.alert-danger
+            %h2
+              = pluralize(@user.errors.count, "error")
+              prohibited this project from being saved:
+
+            %ul
+            - project.errors.full_messages.each do |message|
+              %li= message
+
+        .row
+          .col-sm-2
+            = image_tag @user.image || '', class: 'img-circle form-avatar', width: 80
+          .col-sm-10
+            .form-group
+              = f.label :image
+              = f.text_field :image, class: 'form-control'
+              %span.help-block
+                Provide a URL to an image you'd like to use as an avatar.
+            
+        .form-group
+          = f.label :name
+          = f.text_field :name, class: 'form-control'
+          %span.help-block
+            Let people recognize you by telling us your name.
+            
+        .form-group
+          = f.label :email
+          = f.text_field :email, class: 'form-control'
+          %span.help-block
+            We use your email for finding commits that belong to you.
+
+        .actions
+          = f.submit class: 'btn btn-primary'
+          .pull-right
+            = link_to 'Cancel', user_path(@user), class: 'btn btn-default'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     patch 'users/:id/toggle_admin', to: 'users/profile#toggle_admin', as: :toggle_admin
     get 'users/:id', to: 'users/profile#show', as: :user
     get 'users/:id/edit', to: 'users/profile#edit', as: :edit_user
+    patch 'users/:id', to: 'users/profile#update'
   end
 
   # resources


### PR DESCRIPTION
Allow users to customize their profiles by changing name, email and
avatar URL.

Restrict editing of other users to admins.

Fixes #19