### PR TITLE
Make users follow projects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ Metrics/MethodLength:
   Max: 18
 
 Metrics/ClassLength:
-  Max: 110
+  Max: 150
   Exclude:
     - 'test/**/*'
 

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,9 @@ gem 'omniauth-github'
 gem 'omniauth-gitlab'
 gem 'oauth2'
 
+# Allow users to follow projects
+gem 'acts_as_follower', github: 'tcocca/acts_as_follower'
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: git://github.com/tcocca/acts_as_follower.git
+  revision: c395dd2f1d62a5879e9d084c770dc35e02ee1043
+  specs:
+    acts_as_follower (0.2.1)
+      activerecord (>= 4.0)
+
 GEM
   remote: https://rubygems.org/
   remote: https://rails-assets.org/
@@ -245,6 +252,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts_as_follower!
   byebug
   codeclimate-test-reporter
   coffee-rails (~> 4.2)

--- a/app/assets/javascripts/app/controllers/projects.coffee
+++ b/app/assets/javascripts/app/controllers/projects.coffee
@@ -15,12 +15,9 @@
 
   $scope.deactivateProject = ($origin, $id, $api_url) ->
     $scope.projects["#{$origin}-#{$id}"]['state'] = 'deactivating'
-    $http.patch(
+    $http.delete(
       '/projects/0.json',
-      {
-        origin: $origin, origin_id: $id, api_url: $api_url,
-        project: { active: false }
-      }
+      { params: { origin: $origin, origin_id: $id, api_url: $api_url } }
     ).then(
       successCallback = (response) ->
         $scope.projects["#{$origin}-#{$id}"]['state'] = 'inactive'

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,12 +1,12 @@
 class ProjectsController < ApplicationController
   before_action :authenticate_user!, except: :webhook
-  before_action :set_project, only: [:show, :edit, :update, :destroy]
+  before_action :set_project, only: [:show, :edit, :update]
   skip_before_action :verify_authenticity_token, only: :webhook
 
   # GET /projects
   # GET /projects.json
   def index
-    @projects = current_user.projects.where(active: true).order(:id)
+    @projects = current_user.following_projects.where(active: true).order(:id)
     redirect_to(setup_projects_path) && return unless @projects.any?
   end
 
@@ -63,17 +63,17 @@ class ProjectsController < ApplicationController
   # POST /projects
   # POST /projects.json
   def create
-    @project = Project.where(
-      api_url: project_params[:api_url]
-    ).first_or_initialize
-    @project.user = current_user
-    @project.origin = project_params[:origin]
-    @project.origin_id = project_params[:origin_id]
+    @project = Project.where(api_url: project_params[:api_url])
+                      .first_or_initialize do |p|
+      p.assign_attributes(project_params)
+      p.user = current_user
+    end
     @project.refresh
     @project.active = true
 
     respond_to do |format|
       if @project.save
+        current_user.follow @project
         @project.create_hook(webhook_projects_url) # TODO: send notification on error
         format.html { redirect_to @project, notice: 'Project was successfully created.' }
         format.json { render :show, status: :created, location: @project }
@@ -108,10 +108,18 @@ class ProjectsController < ApplicationController
   # DELETE /projects/1
   # DELETE /projects/1.json
   def destroy
-    @project.delete_hook(webhook_projects_url)
-    @project.destroy
+    @project = get_project_from_collection(Project)
+    notice, redirect_url = unfollow_project
+
+    if current_user.admin? && params[:force]
+      notice, redirect_url = destroy_project
+
+    elsif @project.user == current_user && @project.followers_count.zero?
+      notice, redirect_url = deactivate_project
+    end
+
     respond_to do |format|
-      format.html { redirect_to projects_url, notice: 'Project was successfully destroyed.' }
+      format.html { redirect_to redirect_url, notice: notice }
       format.json { head :no_content }
     end
   end
@@ -120,16 +128,22 @@ class ProjectsController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_project
-    @project = if params[:api_url]
-                 Project.find_by api_url: params[:api_url]
-               elsif params[:origin] && params[:origin_id]
-                 Project.find_by(
-                   origin: params[:origin],
-                   origin_id: params[:origin_id]
-                 )
-               else
-                 Project.find(params[:id])
-               end
+    @project = get_project_from_collection(
+      current_user.admin? ? Project : current_user.projects
+    )
+  end
+
+  def get_project_from_collection(projects)
+    if params[:api_url]
+      projects.find_by api_url: params[:api_url]
+    elsif params[:origin] && params[:origin_id]
+      projects.find_by(
+        origin: params[:origin],
+        origin_id: params[:origin_id]
+      )
+    else
+      projects.find(params[:id])
+    end
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.
@@ -137,5 +151,22 @@ class ProjectsController < ApplicationController
     params.require(:project).permit(
       :active, :origin, :origin_id, :coverage, :build_state, :name, :api_url
     )
+  end
+
+  def unfollow_project
+    current_user.stop_following @project
+    ["You stopped following #{@project.name}", project_url(@project)]
+  end
+
+  def deactivate_project
+    @project.delete_hook(webhook_projects_url)
+    @project.update_attribute(:active, false)
+    ['Project was successfully deactivated', projects_url]
+  end
+
+  def destroy_project
+    @project.delete_hook(webhook_projects_url)
+    @project.destroy
+    ['Project was successfully destroyed', projects_url]
   end
 end

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -1,0 +1,12 @@
+class Follow < ActiveRecord::Base
+  extend ActsAsFollower::FollowerLib
+  extend ActsAsFollower::FollowScopes
+
+  # NOTE: Follows belong to the "followable" interface, and also to followers
+  belongs_to :followable, polymorphic: true
+  belongs_to :follower,   polymorphic: true
+
+  def block!
+    update_attribute(:blocked, true)
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -9,6 +9,8 @@ class Project < ApplicationRecord
   validates :api_url, uniqueness: true
   belongs_to :user
 
+  acts_as_followable
+
   def refresh
     return unless origin
     meta = backend.get_project(api_url)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ApplicationRecord
 
   validates :email, uniqueness: true
 
+  acts_as_follower
+
   def self.new_with_session(params, session)
     super.tap do |_user|
     end

--- a/db/migrate/20160909172428_acts_as_follower_migration.rb
+++ b/db/migrate/20160909172428_acts_as_follower_migration.rb
@@ -1,0 +1,17 @@
+class ActsAsFollowerMigration < ActiveRecord::Migration
+  def self.up
+    create_table :follows, :force => true do |t|
+      t.references :followable, :polymorphic => true, :null => false
+      t.references :follower,   :polymorphic => true, :null => false
+      t.boolean :blocked, :default => false, :null => false
+      t.timestamps
+    end
+
+    add_index :follows, ["follower_id", "follower_type"],     :name => "fk_follows"
+    add_index :follows, ["followable_id", "followable_type"], :name => "fk_followables"
+  end
+
+  def self.down
+    drop_table :follows
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160905065436) do
+ActiveRecord::Schema.define(version: 20160909172428) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,18 @@ ActiveRecord::Schema.define(version: 20160905065436) do
     t.datetime "updated_at"
     t.datetime "created_at"
     t.index ["user_id"], name: "index_account_links_on_user_id", using: :btree
+  end
+
+  create_table "follows", force: :cascade do |t|
+    t.string   "followable_type",                 null: false
+    t.integer  "followable_id",                   null: false
+    t.string   "follower_type",                   null: false
+    t.integer  "follower_id",                     null: false
+    t.boolean  "blocked",         default: false, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["followable_id", "followable_type"], name: "fk_followables", using: :btree
+    t.index ["follower_id", "follower_type"], name: "fk_follows", using: :btree
   end
 
   create_table "projects", force: :cascade do |t|

--- a/test/fixtures/follow.yml
+++ b/test/fixtures/follow.yml
@@ -1,0 +1,6 @@
+alice_follows_github_project:
+  follower: alice (User)
+  followable: github_project (Project)
+alice_follows_gitlab_project:
+  follower: alice (User)
+  followable: gitlab_project (Project)


### PR DESCRIPTION
Projects are now followable and users are able to be
followers. When a user activates a project, they follow
it.

When the owner deactivates a project, the webhook is
removed.

Editing of projects is restricted to owners and admins and
only admins are allowed to completely remove projects
from the database.

This fixes #35