### PR TITLE
Parse errored build state as failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ before_script:
   - gem install rubocop
 script:
   - bin/rails rubocop
-  - bin/rails spec
   - bin/rails teaspoon
+  - bin/rails spec
 deploy:
   provider: heroku
   api_key:

--- a/lib/backends/github.rb
+++ b/lib/backends/github.rb
@@ -60,7 +60,7 @@ module Appatite::Backends
       case state
       when 'pending' then 'running'
       when 'success' then 'success'
-      when 'failed' then 'failed'
+      when 'failed', 'error' then 'failed'
       else 'unknown'
       end
     end

--- a/spec/lib/backends/github_spec.rb
+++ b/spec/lib/backends/github_spec.rb
@@ -70,6 +70,13 @@ describe Appatite::Backends::Github, type: :lib do
         expect(backend.get_project(1)[:state]).to eq('failed')
       end
 
+      it "should parse build state 'error' as 'failed'" do
+        expect(backend).to receive(:get)
+          .with('repos/sample/project/statuses/HEAD')
+          .and_return(json_response([{ state: 'error' }]))
+        expect(backend.get_project(1)[:state]).to eq('failed')
+      end
+
       it "should parse build state 'success'" do
         expect(backend).to receive(:get)
           .with('repos/sample/project/statuses/HEAD')


### PR DESCRIPTION
Have the GitLab library properly parse build state 'error' and
return it as 'failed' to the caller.

Closes #53