### PR TITLE
Guard requires from production in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,13 +3,14 @@
 
 require 'rubocop/rake_task'
 require_relative 'config/application'
-require 'rubocop/rake_task'
-require 'haml_lint/rake_task'
-require 'yamllint/rake_task'
 
 Rails.application.load_tasks
 
 unless Rails.env.production?
+  require 'rubocop/rake_task'
+  require 'haml_lint/rake_task'
+  require 'yamllint/rake_task'
+
   RuboCop::RakeTask.new
 
   HamlLint::RakeTask.new do |t|


### PR DESCRIPTION
Amend the last change to guard the require statements in addition
to the creation of the RakeTask instances.

This will fix the, hopefully, last error when deploying to
production.