### PR TITLE
Use rescue instead of if to guard Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require_relative 'config/application'
 
 Rails.application.load_tasks
 
-unless Rails.env.production?
+begin
   require 'rubocop/rake_task'
   require 'haml_lint/rake_task'
   require 'yamllint/rake_task'
@@ -27,4 +27,6 @@ unless Rails.env.production?
   task lint: %w(rubocop yamllint)
 
   task default: [:lint, :test]
+rescue LoadError
+  puts 'WARNING: Could not load test libraries, perhaps we are in production?'
 end


### PR DESCRIPTION
It seems that deployment to production does not make the
statement Rake.env.production? return true, so instead we change
the guard into a begin/rescue block and rescue on LoadError
exceptions.