### PR TITLE
Insert Google Analytics tracking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ services:
   - postgresql
 before_script:
   - psql -c 'create database appatite_test;' -U postgres
-  - gem install rubocop
 script:
   - bin/rails rubocop
   - bin/rails teaspoon

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,9 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
-
-require 'rubocop/rake_task'
 require_relative 'config/application'
-
 Rails.application.load_tasks
 
-begin
+unless Rails.env.production?
   require 'rubocop/rake_task'
   require 'haml_lint/rake_task'
   require 'yamllint/rake_task'
@@ -27,6 +24,4 @@ begin
   task lint: %w(rubocop yamllint)
 
   task default: [:lint, :test]
-rescue LoadError
-  puts 'WARNING: Could not load test libraries, perhaps we are in production?'
 end

--- a/app/assets/javascripts/analytics.coffee
+++ b/app/assets/javascripts/analytics.coffee
@@ -1,0 +1,42 @@
+class @GoogleAnalytics
+
+  @load: ->
+    # Google Analytics depends on a global _gaq array. window is the global scope.
+    window._gaq = []
+    window._gaq.push ["_setAccount", GoogleAnalytics.analyticsId()]
+
+    # Create a script element and insert it in the DOM
+    ga = document.createElement("script")
+    ga.type = "text/javascript"
+    ga.async = true
+    ga.src = ((if "https:" is document.location.protocol then "https://ssl" else "http://www")) + ".google-analytics.com/ga.js"
+    firstScript = document.getElementsByTagName("script")[0]
+    firstScript.parentNode.insertBefore ga, firstScript
+
+    # If Turbolinks is supported, set up a callback to track pageviews on page:change.
+    # If it isn't supported, just track the pageview now.
+    if typeof Turbolinks isnt 'undefined' and Turbolinks.supported
+      document.addEventListener "page:change", (->
+        GoogleAnalytics.trackPageview()
+      ), true
+    else
+      GoogleAnalytics.trackPageview()
+
+  @trackPageview: (url) ->
+    unless GoogleAnalytics.isLocalRequest()
+      if url
+        window._gaq.push ["_trackPageview", url]
+      else
+        window._gaq.push ["_trackPageview"]
+      window._gaq.push ["_trackPageLoadTime"]
+
+  @isLocalRequest: ->
+    GoogleAnalytics.documentDomainIncludes "local"
+
+  @documentDomainIncludes: (str) ->
+    document.domain.indexOf(str) isnt -1
+
+  @analyticsId: ->
+    'UA-84209765-1'
+
+GoogleAnalytics.load()


### PR DESCRIPTION
Track page views with Google Analytics using a custom Coffeescript
snippet that allows us to support turbolinks.

Closes #68