### PR TITLE
Make Google Analytics work with Turbolinks

### DIFF
--- a/app/assets/javascripts/analytics.coffee
+++ b/app/assets/javascripts/analytics.coffee
@@ -1,0 +1,4 @@
+document.addEventListener 'turbolinks:load', (event) ->
+  if typeof ga is 'function'
+    ga 'set', 'location', event.data.url
+    ga 'send', 'pageview'

--- a/app/views/application/_analytics.haml
+++ b/app/views/application/_analytics.haml
@@ -8,4 +8,3 @@
     ga('create', '#{ApplicationSetting.current.ga_tracking}', 'auto');
     - if user_signed_in?
       ga('set', 'userId', '#{current_user.email}');
-    ga('send', 'pageview');


### PR DESCRIPTION
Since we use Turbolinks, the page is reloaded in-place, so we
need to subscribe to the load event and fire a pageview event
with the proper URL set.