### PR TITLE
Track crashes and error with Sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,9 @@ gem 'acts_as_follower', github: 'tcocca/acts_as_follower'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
+# Collect crash reports
+gem 'sentry-raven'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,6 +246,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sentry-raven (1.2.3)
+      faraday (>= 0.7.6, < 0.10.x)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
     simplecov (0.12.0)
@@ -337,6 +339,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   sass-rails (~> 5.0)
+  sentry-raven
   shoulda-matchers
   spring
   spring-watcher-listen

--- a/README.md
+++ b/README.md
@@ -14,12 +14,21 @@ This is the project for the [Appatite website](http://appatite.herokuapp.com).
 ## Get started
 
 ### Configuration
+#### Authentication
 To enable signing in with Github or Gitlab you need to register an app
 with those providers and save your ID and secret in the configuration file.
 
 Register your application on [Github](https://github.com/settings/developers)
 and [Gitlab](https://gitlab.com/profile/applications) to get your ID and secret.
-Set callback URL to `http://<HOSTNAME>/users/auth/gitlab/callback`.
+Set callback URL to `https://<HOSTNAME>/users/auth/gitlab/callback`.
+
+#### Sentry
+If you want to use Sentry to track app crashes and errors you need to add a line
+like the following to the file `.env`:
+
+```
+SENTRY_DSN=https://8fc8bddc8a5546e4bc0651338590b11c:33fa5b53c6cc4e93a1a16eb040e9f9bd@sentry.io/99408
+```
 
 ### Vagrant
 The easiest way to get everything installed is by using [Vagrant](vagrantup.com).

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -4,4 +4,8 @@ class StaticController < ApplicationController
 
   def pricing
   end
+
+  def crash
+    raise 'This error is for testing purposes'
+  end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,5 @@
+unless Rails.env.test?
+  Raven.configure do |config|
+    config.dsn = ENV['SENTRY_DSN']
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,8 @@ Rails.application.routes.draw do
     post 'webhook', on: :collection
   end
 
-  # static
+  # root
   get '/pricing', to: 'static#pricing'
+  get '/crash', to: 'static#crash'
   root to: 'static#index'
 end

--- a/spec/controllers/static_controller_spec.rb
+++ b/spec/controllers/static_controller_spec.rb
@@ -14,4 +14,10 @@ describe StaticController do
       expect(response).to have_http_status(200)
     end
   end
+
+  describe 'GET crash' do
+    it 'should render error message' do
+      expect { get :crash }.to raise_error(RuntimeError)
+    end
+  end
 end

--- a/spec/routing/root_routing_spec.rb
+++ b/spec/routing/root_routing_spec.rb
@@ -8,4 +8,8 @@ describe StaticController, 'routing' do
   it 'to #pricing' do
     expect(get('/pricing')).to route_to('static#pricing')
   end
+
+  it 'to #crash' do
+    expect(get('/crash')).to route_to('static#crash')
+  end
 end


### PR DESCRIPTION
Add support for sentry.io which allows us to track crashes and
errors in the app.

Closes #71