### PR TITLE
Handle missing location and website

### DIFF
--- a/app/views/layouts/profile.haml
+++ b/app/views/layouts/profile.haml
@@ -12,13 +12,14 @@
           %ul.list-group
             %li.list-group-item
               %span.fa.fa-fw.fa-map-marker
-              = @user.location || 'All over the place'
+              = @user.location.present? ? @user.location : 'All over the place'
             %li.list-group-item
               %span.fa.fa-fw.fa-calendar
               Joined #{time_ago_in_words @user.created_at} ago
-            %li.list-group-item
-              %span.fa.fa-fw.fa-link
-              = @user.website || 'No website'
+            - if @user.website.present?
+              %li.list-group-item
+                %span.fa.fa-fw.fa-link
+                = @user.website || 'No website'
           - if admin? or @user == current_user
             .panel-footer
               = link_to 'Edit profile', edit_user_path(@user), class: 'btn btn-default'

--- a/spec/views/users/profile/show.html.haml_spec.rb
+++ b/spec/views/users/profile/show.html.haml_spec.rb
@@ -9,18 +9,32 @@ describe 'users/profile/show' do
                                 website: 'http://foo.bar',
                                 nickname: 'awesome-user',
                                 location: 'testland')
-    render layout: 'layouts/profile', template: '/users/profile/show'
   end
 
   it 'should display user name' do
+    render layout: 'layouts/profile', template: '/users/profile/show'
     expect(rendered).to have_content 'Awesome User'
   end
 
+  it 'should state default location if missing' do
+    assign :user, create(:user, location: '')
+    render layout: 'layouts/profile', template: '/users/profile/show'
+    expect(rendered).to have_content 'All over the place'
+  end
+
   it 'should display avatar' do
+    render layout: 'layouts/profile', template: '/users/profile/show'
     expect(rendered).to have_selector "img[src='http://img.com/jpg']"
   end
 
   it 'should display overview' do
+    render layout: 'layouts/profile', template: '/users/profile/show'
     expect(rendered).to have_content 'Nice overview'
+  end
+
+  it 'should not display website when missing' do
+    assign :user, create(:user, website: '')
+    render layout: 'layouts/profile', template: '/users/profile/show'
+    expect(rendered).to_not have_selector '.panel span.fa-link'
   end
 end


### PR DESCRIPTION
Link should only be displayed when it is not empty.

If user has not set location, it should display default location.

Closes #91