### PR TITLE
Specify ruby version to run

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '2.3.1'
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -355,5 +355,8 @@ DEPENDENCIES
   webmock
   yamllint
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
    1.13.1


### PR DESCRIPTION
We need to specify which version of Ruby to run so we can force
Heroku to run a version new enough to support all the stuff that
rubocop forces us to use. One example is the `&.` operator which
requires Ruby 2.3.x.

This fixes an issue in production.