### PR TITLE
Move API front page out from ignored folder

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,4 +1,4 @@
---readme doc/API.md
+--readme API.md
 --title 'Appatite API Documentation'
 'app/**/*.rb'
 'lib/**/*.rb'

--- a/API.md
+++ b/API.md
@@ -1,0 +1,1 @@
+Welcome to the API documentation.


### PR DESCRIPTION
The `API.md` (front page for the API documentation) is moved out
from the gitignored `doc/` folder and to the root.